### PR TITLE
Add PostCSS configuration for Tailwind

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- add a PostCSS configuration alongside the Tailwind config so Create React App picks it up

## Testing
- `npm run build:frontend` *(fails: `react-scripts` command not found in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dbae1ad28883258f35705c056f59a5