### PR TITLE
Add TypeScript configuration for backend builds

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript configuration for the backend with ES2020 CommonJS output
- enable strict mode with interop and skip library checks to unblock compilation
- specify src as the compilation root and dist as the output folder

## Testing
- npm run build
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68dbae1c6e5c83258bafc62b926d7669