### PR TITLE
Add CRA TypeScript configuration for frontend

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}


### PR DESCRIPTION
## Summary
- add a Create React App style TypeScript configuration for the frontend workspace so the CRA tooling resolves modules such as `./App`

## Testing
- npm run dev *(fails: `react-scripts` command not found in workspace because the package could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb55792748325ae9c007e288a9e0c