### PR TITLE
Ensure search sort changes trigger updated requests

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -17,7 +17,7 @@ export const SearchPage: React.FC = () => {
     }
   }, []);
 
-  const searchProducts = async (query: string) => {
+  const searchProducts = async (query: string, sortParam = sortBy) => {
     const trimmedQuery = query.trim();
     if (!trimmedQuery) {
       setProducts([]);
@@ -27,7 +27,7 @@ export const SearchPage: React.FC = () => {
 
     setLoading(true);
     try {
-      const response = await fetch(`/api/search?q=${encodeURIComponent(trimmedQuery)}&sortBy=${sortBy}`);
+      const response = await fetch(`/api/search?q=${encodeURIComponent(trimmedQuery)}&sortBy=${sortParam}`);
       const data = await response.json();
       if (data.success) setProducts(data.data.results || []);
     } catch (error) {
@@ -59,7 +59,11 @@ export const SearchPage: React.FC = () => {
             </div>
             <select
               value={sortBy}
-              onChange={(e) => { setSortBy(e.target.value); searchProducts(searchQuery); }}
+              onChange={(e) => {
+                const newSort = e.target.value;
+                setSortBy(newSort);
+                searchProducts(searchQuery, newSort);
+              }}
               className="border border-gray-300 rounded-md px-3 py-2 text-sm"
             >
               <option value="relevance">Pertinence</option>

--- a/frontend/src/pages/__tests__/SearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/SearchPage.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import { SearchPage } from '../SearchPage';
+
+const originalFetch = global.fetch;
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('SearchPage sorting behaviour', () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    (global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    window.history.replaceState({}, '', '/');
+    document.body.innerHTML = '';
+  });
+
+  it('appends the selected sort to the request and updates product order', async () => {
+    const initialResults = [
+      {
+        id: 1,
+        name: 'Produit A',
+        slug: 'produit-a',
+        brand: 'Marque A',
+        category: 'Catégorie',
+        categorySlug: 'categorie',
+        images: [],
+        minPrice: 100,
+        maxPrice: 150,
+        offersCount: 2,
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        name: 'Produit B',
+        slug: 'produit-b',
+        brand: 'Marque B',
+        category: 'Catégorie',
+        categorySlug: 'categorie',
+        images: [],
+        minPrice: 200,
+        maxPrice: 250,
+        offersCount: 3,
+        createdAt: '2024-01-02T00:00:00Z',
+      },
+    ];
+
+    const sortedResults = [...initialResults].reverse();
+
+    mockFetch
+      .mockResolvedValueOnce({
+        json: async () => ({ success: true, data: { results: initialResults } }),
+      } as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({ success: true, data: { results: sortedResults } }),
+      } as Response);
+
+    window.history.pushState({}, '', '/search?q=ordinateur');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchPage />);
+    });
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toContain('sortBy=relevance');
+
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+
+    await act(async () => {
+      select.value = 'price_desc';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      await flushPromises();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1][0]).toContain('sortBy=price_desc');
+
+    const headings = Array.from(container.querySelectorAll('h3'));
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      'Produit B',
+      'Produit A',
+    ]);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the search page forwards the selected sort option to the API request
- add a regression test that confirms the request URL uses the new sort value and that the rendered order updates accordingly

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dbba2c5e088325896201db7fd6fcf0