### PR TITLE
Integrate Prisma persistence for catalog data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### Déjà disponibles
 
 - **Page d'accueil interactive** avec suggestions de recherches populaires et mise en avant du projet.
-- **Recherche de produits** sur une API Express alimentée par des données de démonstration.
+- **Recherche de produits** sur une API Express connectée à PostgreSQL via Prisma.
 - **Tri des résultats** (pertinence, prix croissant/décroissant, ordre alphabétique) directement depuis l'interface.
 - **Cartes produits détaillées** affichant prix minimum/maximum, nombre d'offres et visuels.
 - **Interface responsive** construite avec Tailwind CSS.
@@ -39,7 +39,7 @@
 ### Stack actuelle
 
 - **Frontend** : React 18, React Router DOM, TypeScript, Create React App, Tailwind CSS.
-- **Backend** : Node.js 18, Express, TypeScript (compilé avec `tsc`), gestion de la config via `dotenv`, données mockées en mémoire.
+- **Backend** : Node.js 18, Express, TypeScript (compilé avec `tsc`), Prisma Client pour PostgreSQL, gestion de la config via `dotenv`.
 - **Outils** : TSX pour le rechargement à chaud côté serveur, PostCSS & Autoprefixer pour le pipeline CSS.
 
 ### Stack envisagée
@@ -59,8 +59,8 @@
 
 2. **Configurer l'environnement**
    ```bash
-   cp .env.example .env
-   # Éditer .env avec vos configurations
+   cp backend/.env.example backend/.env
+   # Éditer backend/.env avec vos configurations (PORT, DATABASE_URL)
    ```
 
 3. **Installer les dépendances**
@@ -77,6 +77,23 @@
    ```bash
    npm run dev
    ```
+
+## 🗃️ Base de données & Prisma
+
+Une stack PostgreSQL + Prisma est désormais utilisée pour persister les produits, marchands et offres. Après avoir démarré PostgreSQL (via `docker-compose` ou votre instance locale), exécutez les commandes suivantes dans le dossier `backend` :
+
+```bash
+# Générer/mettre à jour le client Prisma
+npm run prisma:generate
+
+# Appliquer la migration initiale
+npm run prisma:migrate -- --name init
+
+# Insérer des données de démonstration (marchands marocains et offres)
+npm run db:seed
+```
+
+> ℹ️ La commande `npm run db:seed` injecte plusieurs offres issues de marchands marocains comme Electro Planet, Microchoix et Jumia afin de disposer d'un catalogue exploitable immédiatement dans le frontend.
 
 ## 📱 Accès
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+# Backend server configuration
+PORT=3001
+
+# PostgreSQL connection string used by Prisma and the API
+DATABASE_URL="postgresql://atlas_user:atlas_password@localhost:5432/atlas_taman?schema=public"

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,13 @@
     "dev": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "build": "tsc",
-    "test": "echo \"Tests backend à implémenter\""
+    "test": "echo \"Tests backend à implémenter\"",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "db:seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@prisma/client": "^5.11.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2"
@@ -18,7 +22,11 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.10.6",
+    "prisma": "^5.11.0",
     "tsx": "^4.6.2",
     "typescript": "^5.3.3"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/backend/prisma/migration_lock.toml
+++ b/backend/prisma/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/backend/prisma/migrations/20240215120000_init/migration.sql
+++ b/backend/prisma/migrations/20240215120000_init/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" SERIAL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "brand" TEXT NOT NULL,
+    "model" TEXT,
+    "category" TEXT NOT NULL,
+    "categorySlug" TEXT NOT NULL,
+    "description" TEXT,
+    "images" TEXT[] NOT NULL,
+    "specifications" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Merchant" (
+    "id" SERIAL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "url" TEXT,
+    "logoUrl" TEXT,
+    "city" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Offer" (
+    "id" SERIAL PRIMARY KEY,
+    "price" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'MAD',
+    "shippingFee" INTEGER,
+    "isAvailable" BOOLEAN NOT NULL DEFAULT true,
+    "url" TEXT,
+    "productId" INTEGER NOT NULL,
+    "merchantId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Offer_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Offer_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Product_slug_key" ON "Product"("slug");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,50 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id           Int       @id @default(autoincrement())
+  name         String
+  slug         String    @unique
+  brand        String
+  model        String?
+  category     String
+  categorySlug String
+  description  String?
+  images       String[]  @db.Text[]
+  specifications Json?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+  offers       Offer[]
+}
+
+model Merchant {
+  id        Int      @id @default(autoincrement())
+  name      String
+  url       String?
+  logoUrl   String?
+  city      String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  offers    Offer[]
+}
+
+model Offer {
+  id          Int       @id @default(autoincrement())
+  price       Int
+  currency    String    @default("MAD")
+  shippingFee Int?
+  isAvailable Boolean   @default(true)
+  url         String?
+  product     Product   @relation(fields: [productId], references: [id], onDelete: Cascade)
+  productId   Int
+  merchant    Merchant  @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+  merchantId  Int
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,168 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('🌱 Seeding database with merchants, products and offers...');
+
+  await prisma.offer.deleteMany();
+  await prisma.product.deleteMany();
+  await prisma.merchant.deleteMany();
+
+  const merchants = await Promise.all([
+    prisma.merchant.create({
+      data: {
+        name: 'Electro Planet',
+        city: 'Casablanca',
+        url: 'https://www.electroplanet.ma',
+        logoUrl: 'https://via.placeholder.com/120x120/2563eb/ffffff?text=EP'
+      }
+    }),
+    prisma.merchant.create({
+      data: {
+        name: 'Microchoix',
+        city: 'Rabat',
+        url: 'https://www.microchoix.ma',
+        logoUrl: 'https://via.placeholder.com/120x120/16a34a/ffffff?text=MC'
+      }
+    }),
+    prisma.merchant.create({
+      data: {
+        name: 'Jumia Maroc',
+        city: 'Casablanca',
+        url: 'https://www.jumia.ma',
+        logoUrl: 'https://via.placeholder.com/120x120/f97316/ffffff?text=JM'
+      }
+    })
+  ]);
+
+  await prisma.product.create({
+    data: {
+      name: 'iPhone 15 Pro 128GB',
+      slug: 'iphone-15-pro-128gb',
+      brand: 'Apple',
+      category: 'Smartphones',
+      categorySlug: 'smartphones',
+      model: 'A3103',
+      images: ['https://via.placeholder.com/300x300/0ea5e9/ffffff?text=iPhone+15+Pro'],
+      specifications: {
+        screen: '6.1 pouces',
+        ram: '8 GB',
+        storage: '128 GB',
+        chipset: 'Apple A17 Pro'
+      },
+      offers: {
+        create: [
+          {
+            price: 12999,
+            shippingFee: 49,
+            merchant: { connect: { id: merchants[0].id } },
+            url: 'https://www.electroplanet.ma/iphone-15-pro'
+          },
+          {
+            price: 13299,
+            shippingFee: 0,
+            merchant: { connect: { id: merchants[1].id } },
+            url: 'https://www.microchoix.ma/iphone-15-pro-128gb'
+          },
+          {
+            price: 13599,
+            shippingFee: 0,
+            merchant: { connect: { id: merchants[2].id } },
+            url: 'https://www.jumia.ma/iphone-15-pro-128gb'
+          }
+        ]
+      }
+    }
+  });
+
+  await prisma.product.create({
+    data: {
+      name: 'Samsung Galaxy S24 Ultra 256GB',
+      slug: 'samsung-galaxy-s24-ultra',
+      brand: 'Samsung',
+      category: 'Smartphones',
+      categorySlug: 'smartphones',
+      model: 'SM-S928B',
+      images: ['https://via.placeholder.com/300x300/6366f1/ffffff?text=Galaxy+S24'],
+      specifications: {
+        screen: '6.8 pouces',
+        ram: '12 GB',
+        storage: '256 GB',
+        chipset: 'Snapdragon 8 Gen 3'
+      },
+      offers: {
+        create: [
+          {
+            price: 15299,
+            shippingFee: 99,
+            merchant: { connect: { id: merchants[0].id } },
+            url: 'https://www.electroplanet.ma/galaxy-s24-ultra'
+          },
+          {
+            price: 15599,
+            shippingFee: 49,
+            merchant: { connect: { id: merchants[1].id } },
+            url: 'https://www.microchoix.ma/samsung-galaxy-s24-ultra-256gb'
+          },
+          {
+            price: 15499,
+            shippingFee: 0,
+            merchant: { connect: { id: merchants[2].id } },
+            url: 'https://www.jumia.ma/samsung-galaxy-s24-ultra-256gb'
+          }
+        ]
+      }
+    }
+  });
+
+  await prisma.product.create({
+    data: {
+      name: 'PlayStation 5 Slim',
+      slug: 'playstation-5-slim',
+      brand: 'Sony',
+      category: 'Gaming',
+      categorySlug: 'gaming',
+      images: ['https://via.placeholder.com/300x300/8b5cf6/ffffff?text=PS5+Slim'],
+      specifications: {
+        storage: '1 TB',
+        resolution: '4K',
+        bundle: 'Manette DualSense incluse'
+      },
+      offers: {
+        create: [
+          {
+            price: 5499,
+            shippingFee: 0,
+            merchant: { connect: { id: merchants[0].id } },
+            url: 'https://www.electroplanet.ma/ps5-slim'
+          },
+          {
+            price: 5590,
+            shippingFee: 79,
+            merchant: { connect: { id: merchants[1].id } },
+            url: 'https://www.microchoix.ma/playstation-5-slim'
+          },
+          {
+            price: 5699,
+            shippingFee: 0,
+            merchant: { connect: { id: merchants[2].id } },
+            url: 'https://www.jumia.ma/playstation-5-slim'
+          }
+        ]
+      }
+    }
+  });
+
+  console.log('✅ Seed completed.');
+}
+
+main()
+  .catch((error) => {
+    console.error('❌ Seed failed', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,12 +1,81 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import { mockProducts } from './mockData';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const prisma = new PrismaClient();
+
+type ProductWithRelations = Prisma.ProductGetPayload<{
+  include: { offers: { include: { merchant: true } } };
+}>;
+
+const formatProductResponse = (product: ProductWithRelations) => {
+  const offers = product.offers.map((offer) => {
+    const totalPrice = offer.price + (offer.shippingFee ?? 0);
+
+    return {
+      id: offer.id,
+      price: offer.price,
+      totalPrice,
+      currency: offer.currency,
+      shippingFee: offer.shippingFee,
+      isAvailable: offer.isAvailable,
+      url: offer.url,
+      merchant: {
+        id: offer.merchant.id,
+        name: offer.merchant.name,
+        url: offer.merchant.url,
+        logoUrl: offer.merchant.logoUrl,
+        city: offer.merchant.city,
+      },
+      createdAt: offer.createdAt.toISOString(),
+      updatedAt: offer.updatedAt.toISOString(),
+    };
+  });
+
+  const offerTotals = offers.map((offer) => offer.totalPrice);
+  const minPrice = offers.length ? Math.min(...offers.map((offer) => offer.price)) : 0;
+  const maxPrice = offers.length ? Math.max(...offers.map((offer) => offer.price)) : 0;
+  const minTotalPrice = offerTotals.length ? Math.min(...offerTotals) : 0;
+
+  return {
+    id: product.id,
+    name: product.name,
+    slug: product.slug,
+    brand: product.brand,
+    model: product.model,
+    category: product.category,
+    categorySlug: product.categorySlug,
+    images: product.images,
+    minPrice,
+    maxPrice,
+    minTotalPrice,
+    offersCount: offers.length,
+    specifications: product.specifications,
+    createdAt: product.createdAt.toISOString(),
+    offers,
+  };
+};
+
+const loadProducts = async (where?: Prisma.ProductWhereInput) => {
+  const products = await prisma.product.findMany({
+    where,
+    include: {
+      offers: {
+        include: {
+          merchant: true,
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return products.map(formatProductResponse);
+};
 
 app.use(cors());
 app.use(express.json());
@@ -15,33 +84,64 @@ app.get('/api/health', (req, res) => {
   res.json({ status: 'OK', message: 'Atlas Taman GPT API 🚀' });
 });
 
-app.get('/api/search', (req, res) => {
-  const { q, sortBy = 'relevance' } = req.query;
-  let results = [...mockProducts];
-  
-  if (q) {
-    const query = (q as string).toLowerCase();
-    results = results.filter(p => 
-      p.name.toLowerCase().includes(query) ||
-      p.brand.toLowerCase().includes(query)
-    );
+app.get('/api/search', async (req, res) => {
+  try {
+    const { q, sortBy = 'relevance' } = req.query;
+    const searchTerm = typeof q === 'string' ? q.trim() : '';
+
+    const where: Prisma.ProductWhereInput | undefined = searchTerm
+      ? {
+          OR: [
+            { name: { contains: searchTerm, mode: 'insensitive' } },
+            { brand: { contains: searchTerm, mode: 'insensitive' } },
+            { category: { contains: searchTerm, mode: 'insensitive' } },
+          ],
+        }
+      : undefined;
+
+    const products = await loadProducts(where);
+
+    const sortedProducts = [...products];
+
+    if (sortBy === 'price_asc') {
+      sortedProducts.sort((a, b) => (a.minTotalPrice ?? a.minPrice) - (b.minTotalPrice ?? b.minPrice));
+    } else if (sortBy === 'price_desc') {
+      sortedProducts.sort((a, b) => (b.minTotalPrice ?? b.minPrice) - (a.minTotalPrice ?? a.minPrice));
+    } else if (sortBy === 'name') {
+      sortedProducts.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    res.json({
+      success: true,
+      data: { results: sortedProducts, pagination: { total: sortedProducts.length } },
+    });
+  } catch (error) {
+    console.error('Erreur lors de la recherche de produits', error);
+    res.status(500).json({ success: false, error: 'Une erreur est survenue lors de la recherche.' });
   }
-  
-  if (sortBy === 'price_asc') results.sort((a, b) => a.minPrice - b.minPrice);
-  if (sortBy === 'price_desc') results.sort((a, b) => b.minPrice - a.minPrice);
-  if (sortBy === 'name') results.sort((a, b) => a.name.localeCompare(b.name));
-  
-  res.json({
-    success: true,
-    data: { results, pagination: { total: results.length } }
-  });
 });
 
-app.get('/api/products', (req, res) => {
-  res.json({ success: true, data: { products: mockProducts } });
+app.get('/api/products', async (req, res) => {
+  try {
+    const products = await loadProducts();
+
+    res.json({ success: true, data: { products } });
+  } catch (error) {
+    console.error('Erreur lors de la récupération des produits', error);
+    res.status(500).json({ success: false, error: 'Impossible de charger les produits.' });
+  }
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`🚀 API Atlas Taman GPT sur le port ${PORT}`);
   console.log(`🔍 Search: http://localhost:${PORT}/api/search?q=iphone`);
 });
+
+const shutdown = async () => {
+  console.log('👋 Arrêt du serveur, fermeture de la connexion Prisma...');
+  await prisma.$disconnect();
+  server.close(() => process.exit(0));
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/frontend/src/components/product/ProductCard.tsx
+++ b/frontend/src/components/product/ProductCard.tsx
@@ -19,6 +19,13 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, showDiscount 
     ? Math.round(((product.maxPrice - product.minPrice) / product.maxPrice) * 100)
     : 0;
 
+  const bestOffer = product.offers && product.offers.length > 0
+    ? product.offers.reduce((best, offer) => {
+        const bestTotal = best ? best.totalPrice : Number.POSITIVE_INFINITY;
+        return offer.totalPrice < bestTotal ? offer : best;
+      }, product.offers[0])
+    : undefined;
+
   return (
     <div className="bg-white rounded-lg shadow-md hover:shadow-xl transition-all duration-300 cursor-pointer overflow-hidden group">
       <div className="relative h-48 bg-gray-100 overflow-hidden">
@@ -56,8 +63,25 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, showDiscount 
             <span className="text-sm text-gray-400 line-through">{formatPrice(product.maxPrice)}</span>
           )}
         </div>
-        <div className="flex items-center justify-between text-xs text-gray-500 mb-3">
-          <span>🏪 {product.offersCount} {product.offersCount > 1 ? 'offres' : 'offre'}</span>
+        <div className="space-y-2 text-xs text-gray-600 mb-3">
+          <div className="flex items-center justify-between">
+            <span>🏪 {product.offersCount} {product.offersCount > 1 ? 'offres' : 'offre'}</span>
+            {bestOffer?.merchant?.name && (
+              <span className="text-gray-500">Meilleur prix : {bestOffer.merchant.name}</span>
+            )}
+          </div>
+          {bestOffer && (
+            <div className="flex items-center justify-between">
+              <span>🚚 Livraison</span>
+              <span className="text-gray-700">
+                {bestOffer.shippingFee != null
+                  ? bestOffer.shippingFee > 0
+                    ? `${formatPrice(bestOffer.shippingFee)} supplémentaires`
+                    : 'Offerte'
+                  : 'NC'}
+              </span>
+            </div>
+          )}
         </div>
         <button className="w-full bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors">
           Voir les offres

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,24 @@
+export interface Merchant {
+  id: number;
+  name: string;
+  url?: string | null;
+  logoUrl?: string | null;
+  city?: string | null;
+}
+
+export interface Offer {
+  id: number;
+  price: number;
+  totalPrice: number;
+  currency: string;
+  shippingFee?: number | null;
+  isAvailable: boolean;
+  url?: string | null;
+  merchant: Merchant;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Product {
   id: number;
   name: string;
@@ -9,7 +30,9 @@ export interface Product {
   images: string[];
   minPrice: number;
   maxPrice: number;
+  minTotalPrice?: number;
   offersCount: number;
+  offers?: Offer[];
   specifications?: Record<string, any>;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- add Prisma schema, initial migration and seed script for products, merchants and offers
- update the Express API to serve data from PostgreSQL via Prisma instead of in-memory mocks
- document the database workflow and adjust the frontend to display merchant and delivery details

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dbbc54fe448325aab623a9e63bc6e8