### PR TITLE
Implement product integrations and aggregator

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,16 +7,17 @@
     "dev": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "build": "tsc",
-    "test": "echo \"Tests backend à implémenter\"",
+    "test": "tsc && node --test dist/**/*.test.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "db:seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/client": "^5.11.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "lru-cache": "^10.2.0",
+    "p-limit": "^4.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/backend/src/__tests__/server.test.ts
+++ b/backend/src/__tests__/server.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Server } from 'http';
+
+process.env.NODE_ENV = 'test';
+process.env.USE_LIVE_MERCHANT_APIS = 'false';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { app } = require('../server');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { productAggregator } = require('../services/productAggregator');
+
+const startServer = async (): Promise<{ server: Server; url: string }> => {
+  return new Promise((resolve) => {
+    const instance = app.listen(0, () => {
+      const address = instance.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server: instance, url: `http://127.0.0.1:${port}` });
+    });
+  });
+};
+
+test('returns aggregated products on /api/search', async () => {
+  const { server, url } = await startServer();
+  try {
+    const response = await fetch(`${url}/api/search?q=iphone`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.success, true);
+    assert.ok(Array.isArray(body.data.results));
+    assert.equal(body.data.pagination.total, body.data.results.length);
+    assert.ok(Array.isArray(body.data.metadata.integrations));
+  } finally {
+    server.close();
+  }
+});
+
+test('returns aggregated catalogue on /api/products', async () => {
+  const { server, url } = await startServer();
+  try {
+    const response = await fetch(`${url}/api/products`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.success, true);
+    assert.ok(Array.isArray(body.data.products));
+    assert.ok(Array.isArray(body.data.metadata.integrations));
+  } finally {
+    server.close();
+  }
+});
+
+test('handles aggregator failures gracefully', async () => {
+  const originalSearch = productAggregator.search;
+  (productAggregator as { search: typeof originalSearch }).search = async () => {
+    throw new Error('boom');
+  };
+
+  const { server, url } = await startServer();
+  try {
+    const response = await fetch(`${url}/api/search?q=error`);
+    assert.equal(response.status, 500);
+    const body = await response.json();
+    assert.equal(body.success, false);
+  } finally {
+    (productAggregator as { search: typeof originalSearch }).search = originalSearch;
+    server.close();
+  }
+});

--- a/backend/src/integrations/fixtures/merchantData.ts
+++ b/backend/src/integrations/fixtures/merchantData.ts
@@ -1,0 +1,168 @@
+import { MerchantAvailability, MerchantProfile } from '../types';
+
+export interface MerchantFixture {
+  productId: string;
+  slug: string;
+  title: string;
+  brand: string;
+  category: string;
+  image: string;
+  price: number;
+  currency: string;
+  shippingFee?: number;
+  availability: MerchantAvailability;
+  url: string;
+  keywords: string[];
+}
+
+export const merchantProfiles: Record<string, MerchantProfile> = {
+  electroplanet: {
+    id: 'electroplanet',
+    name: 'Electroplanet',
+    url: 'https://www.electroplanet.ma',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/7/73/Electroplanet_logo.png',
+  },
+  jumia: {
+    id: 'jumia',
+    name: 'Jumia',
+    url: 'https://www.jumia.ma',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/0/0d/Jumia-Logo.png',
+  },
+  marjane: {
+    id: 'marjane',
+    name: 'Marjane',
+    url: 'https://www.marjane.ma',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/fr/8/80/Marjane_logo.png',
+  },
+  bim: {
+    id: 'bim',
+    name: 'BIM',
+    url: 'https://www.bim.ma',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/d/d3/Bim_logo.png',
+  },
+  decathlon: {
+    id: 'decathlon',
+    name: 'Decathlon',
+    url: 'https://www.decathlon.ma',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/6/6f/Decathlon_Logo.svg',
+  },
+  hm: {
+    id: 'hm',
+    name: 'H&M',
+    url: 'https://www2.hm.com',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/5/53/H%26M-Logo.svg',
+  },
+};
+
+const sharedProducts: MerchantFixture[] = [
+  {
+    productId: 'iphone-15-pro-128gb',
+    slug: 'iphone-15-pro-128gb',
+    title: 'Apple iPhone 15 Pro 128GB',
+    brand: 'Apple',
+    category: 'Smartphones',
+    image: 'https://images.atlas-taman.dev/mock/iphone-15-pro.jpg',
+    price: 13499,
+    currency: 'MAD',
+    shippingFee: 0,
+    availability: 'in_stock',
+    url: 'https://example.com/iphone-15-pro',
+    keywords: ['iphone', 'apple', 'smartphone', '15 pro'],
+  },
+  {
+    productId: 'samsung-galaxy-s24-ultra',
+    slug: 'samsung-galaxy-s24-ultra',
+    title: 'Samsung Galaxy S24 Ultra 256GB',
+    brand: 'Samsung',
+    category: 'Smartphones',
+    image: 'https://images.atlas-taman.dev/mock/galaxy-s24-ultra.jpg',
+    price: 14999,
+    currency: 'MAD',
+    shippingFee: 99,
+    availability: 'in_stock',
+    url: 'https://example.com/samsung-galaxy-s24-ultra',
+    keywords: ['s24', 'samsung', 'galaxy', 'ultra'],
+  },
+  {
+    productId: 'playstation-5-slim',
+    slug: 'playstation-5-slim',
+    title: 'PlayStation 5 Slim',
+    brand: 'Sony',
+    category: 'Gaming',
+    image: 'https://images.atlas-taman.dev/mock/ps5-slim.jpg',
+    price: 5799,
+    currency: 'MAD',
+    shippingFee: 49,
+    availability: 'in_stock',
+    url: 'https://example.com/playstation-5-slim',
+    keywords: ['ps5', 'playstation', 'gaming', 'console'],
+  },
+  {
+    productId: 'hm-linen-shirt',
+    slug: 'hm-linen-shirt',
+    title: 'Chemise en Lin Homme',
+    brand: 'H&M',
+    category: 'Mode',
+    image: 'https://images.atlas-taman.dev/mock/hm-shirt.jpg',
+    price: 399,
+    currency: 'MAD',
+    shippingFee: 0,
+    availability: 'in_stock',
+    url: 'https://example.com/hm-linen-shirt',
+    keywords: ['chemise', 'lin', 'mode', 'shirt'],
+  },
+];
+
+const adjustPrices = (base: MerchantFixture[], adjustments: Partial<MerchantFixture>[]): MerchantFixture[] => {
+  return base.map((item, index) => ({
+    ...item,
+    ...(adjustments[index] ?? {}),
+  }));
+};
+
+export const merchantFixtures: Record<string, MerchantFixture[]> = {
+  electroplanet: adjustPrices(sharedProducts, [
+    {},
+    { price: 15249, shippingFee: 0 },
+    { price: 5699, shippingFee: 0 },
+    { price: 379, shippingFee: 0 },
+  ]),
+  jumia: adjustPrices(sharedProducts, [
+    { price: 13349, shippingFee: 29 },
+    { price: 14899, shippingFee: 49 },
+    { price: 5999, shippingFee: 99 },
+    { price: 349, shippingFee: 29 },
+  ]),
+  marjane: adjustPrices(sharedProducts, [
+    { price: 13599, shippingFee: 0 },
+    { price: 15049, shippingFee: 0 },
+    { price: 5899, shippingFee: 0 },
+    { price: 409, shippingFee: 0 },
+  ]),
+  bim: adjustPrices(sharedProducts, [
+    { price: 13649, shippingFee: 0 },
+    { price: 15149, shippingFee: 0 },
+    { price: 5890, shippingFee: 0 },
+    { price: 399, shippingFee: 0 },
+  ]),
+  decathlon: adjustPrices(sharedProducts, [
+    { price: 13999, shippingFee: 0 },
+    { price: 15499, shippingFee: 0 },
+    { price: 5599, shippingFee: 0 },
+    { price: 0, availability: 'out_of_stock', shippingFee: 0 },
+  ]).map((item) => ({
+    ...item,
+    category: item.category === 'Gaming' ? 'Sport & Loisirs' : item.category,
+    keywords: item.keywords.concat('decathlon'),
+  })),
+  hm: adjustPrices(sharedProducts, [
+    { price: 0, availability: 'out_of_stock', shippingFee: 0 },
+    { price: 0, availability: 'out_of_stock', shippingFee: 0 },
+    { price: 0, availability: 'out_of_stock', shippingFee: 0 },
+    { price: 379, shippingFee: 19 },
+  ]).map((item) => ({
+    ...item,
+    keywords: item.keywords.concat(['vetement', 'h&m']),
+    category: item.slug === 'hm-linen-shirt' ? 'Mode' : item.category,
+  })),
+};

--- a/backend/src/integrations/index.ts
+++ b/backend/src/integrations/index.ts
@@ -1,0 +1,13 @@
+import { createIntegrationFromFixtures } from './utils';
+import { MerchantIntegration } from './types';
+
+export const createDefaultIntegrations = (): MerchantIntegration[] => [
+  createIntegrationFromFixtures('electroplanet', 'Electroplanet', 'https://www.electroplanet.ma/catalogsearch/result/?q='),
+  createIntegrationFromFixtures('jumia', 'Jumia', 'https://www.jumia.ma/catalog/?q='),
+  createIntegrationFromFixtures('marjane', 'Marjane', 'https://www.marjane.ma/search?q='),
+  createIntegrationFromFixtures('bim', 'BIM', 'https://www.bim.ma/recherche?query='),
+  createIntegrationFromFixtures('decathlon', 'Decathlon', 'https://www.decathlon.ma/search?q='),
+  createIntegrationFromFixtures('hm', 'H&M', 'https://www2.hm.com/fr_ma/search-results.html?q='),
+];
+
+export * from './types';

--- a/backend/src/integrations/types.ts
+++ b/backend/src/integrations/types.ts
@@ -1,0 +1,33 @@
+export type MerchantAvailability = 'in_stock' | 'out_of_stock' | 'unknown';
+
+export interface MerchantProfile {
+  id: string;
+  name: string;
+  url: string;
+  logoUrl?: string;
+  city?: string;
+}
+
+export interface MerchantOffer {
+  offerId: string;
+  merchant: MerchantProfile;
+  productId: string;
+  slug: string;
+  title: string;
+  brand?: string;
+  category?: string;
+  image?: string;
+  price: number;
+  currency: string;
+  shippingFee?: number;
+  availability: MerchantAvailability;
+  url: string;
+  scrapedAt: string;
+}
+
+export interface MerchantIntegration {
+  readonly id: string;
+  readonly label: string;
+  readonly profile: MerchantProfile;
+  search(query: string): Promise<MerchantOffer[]>;
+}

--- a/backend/src/integrations/utils.ts
+++ b/backend/src/integrations/utils.ts
@@ -1,0 +1,166 @@
+import { MerchantFixture, merchantFixtures, merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+
+const LIVE_DATA_FLAG = 'USE_LIVE_MERCHANT_APIS';
+
+const fetchImpl: typeof fetch = (...args) => {
+  if (typeof fetch === 'undefined') {
+    throw new Error('Global fetch is not available');
+  }
+  return fetch(...args);
+};
+
+export const normalizeText = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+export const normalizeQuery = (query: string) => normalizeText(query.trim());
+
+export const filterFixturesByQuery = (merchantId: string, query: string): MerchantFixture[] => {
+  const fixtures = merchantFixtures[merchantId] ?? [];
+  if (!query) {
+    return fixtures;
+  }
+
+  const normalizedQuery = normalizeQuery(query);
+  return fixtures.filter((item) => {
+    const haystack = normalizeText(
+      [item.slug, item.title, item.brand, item.category, ...(item.keywords ?? [])].join(' ')
+    );
+    return normalizedQuery
+      .split(/\s+/)
+      .filter(Boolean)
+      .every((term) => haystack.includes(term));
+  });
+};
+
+export const shouldUseLiveData = () => process.env[LIVE_DATA_FLAG] === 'true';
+
+const buildFixtureHtml = (merchantId: string, fixtures: MerchantFixture[]) => {
+  const merchant = merchantProfiles[merchantId];
+  const articles = fixtures
+    .map((item) => `
+      <article class="product-card" data-merchant-id="${merchant.id}" data-merchant-name="${merchant.name}" data-merchant-url="${merchant.url}" data-merchant-logo="${merchant.logoUrl ?? ''}" data-product-id="${item.productId}" data-product-slug="${item.slug}" data-product-url="${item.url}" data-price="${item.price}" data-currency="${item.currency}" data-shipping-fee="${item.shippingFee ?? ''}" data-availability="${item.availability}">
+        <h3 class="product-title">${item.title}</h3>
+        <span class="product-brand">${item.brand}</span>
+        <span class="product-category">${item.category}</span>
+        <img class="product-image" src="${item.image}" alt="${item.title}" />
+      </article>
+    `)
+    .join('');
+
+  return `<section class="catalog">${articles}</section>`;
+};
+
+const attributePattern = /([a-zA-Z0-9-:]+)="([^"]*)"/g;
+
+const extractAttributes = (fragment: string) => {
+  const attributes: Record<string, string> = {};
+  fragment.replace(attributePattern, (_, key, value) => {
+    attributes[key] = value;
+    return '';
+  });
+  return attributes;
+};
+
+const extractText = (html: string, selector: string) => {
+  const regex = new RegExp(`<${selector}[^>]*>([\\s\\S]*?)<\\/${selector}>`, 'i');
+  const match = regex.exec(html);
+  return match ? match[1].trim() : '';
+};
+
+const extractImageSrc = (html: string) => {
+  const match = /<img[^>]*class="product-image"[^>]*src="([^"]*)"/i.exec(html);
+  return match ? match[1] : undefined;
+};
+
+export const parseOffersFromHtml = (merchantId: string, html: string): MerchantOffer[] => {
+  const merchant = merchantProfiles[merchantId];
+  const offers: MerchantOffer[] = [];
+  const articleRegex = /<article class="product-card"([^>]*)>([\s\S]*?)<\/article>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = articleRegex.exec(html)) !== null) {
+    const [, attributesRaw, body] = match;
+    const attributes = extractAttributes(attributesRaw);
+    const productId = attributes['data-product-id'];
+    const slug = attributes['data-product-slug'];
+    const price = Number(attributes['data-price']);
+    const currency = (attributes['data-currency'] ?? 'MAD').toUpperCase();
+    const shippingFeeAttr = attributes['data-shipping-fee'];
+    const shippingFee = shippingFeeAttr ? Number(shippingFeeAttr) : undefined;
+    const availabilityAttr = attributes['data-availability'];
+    const availability = availabilityAttr === 'out_of_stock'
+      ? 'out_of_stock'
+      : availabilityAttr === 'in_stock'
+      ? 'in_stock'
+      : 'unknown';
+
+    const title = extractText(body, 'h3');
+    const brandMatch = /<span class="product-brand">([\s\S]*?)<\/span>/i.exec(body);
+    const brand = brandMatch ? brandMatch[1].trim() : '';
+    const categoryMatch = /<span class="product-category">([\s\S]*?)<\/span>/i.exec(body);
+    const category = categoryMatch ? categoryMatch[1].trim() : '';
+    const image = extractImageSrc(body);
+    const url = attributes['data-product-url'] ?? merchant.url;
+
+    if (!productId || !slug || !title || Number.isNaN(price)) {
+      continue;
+    }
+
+    offers.push({
+      offerId: `${merchant.id}-${productId}`,
+      merchant,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image,
+      price,
+      currency,
+      shippingFee,
+      availability,
+      url,
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const fetchHtmlForMerchant = async (
+  merchantId: string,
+  searchUrl: string,
+  query: string
+): Promise<string> => {
+  if (shouldUseLiveData()) {
+    const response = await fetchImpl(`${searchUrl}${encodeURIComponent(query)}`);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.text();
+  }
+
+  const fixtures = filterFixturesByQuery(merchantId, query);
+  return buildFixtureHtml(merchantId, fixtures);
+};
+
+export const createIntegrationFromFixtures = (
+  merchantId: keyof typeof merchantFixtures,
+  label: string,
+  searchUrl: string
+): MerchantIntegration => {
+  const profile = merchantProfiles[merchantId];
+  return {
+    id: merchantId,
+    label,
+    profile,
+    async search(query: string) {
+      const html = await fetchHtmlForMerchant(merchantId, searchUrl, query);
+      return parseOffersFromHtml(merchantId, html);
+    },
+  };
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,119 +1,51 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import { Prisma, PrismaClient } from '@prisma/client';
+import { productAggregator, AggregatedProduct } from './services/productAggregator';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
-const prisma = new PrismaClient();
-
-type ProductWithRelations = Prisma.ProductGetPayload<{
-  include: { offers: { include: { merchant: true } } };
-}>;
-
-const formatProductResponse = (product: ProductWithRelations) => {
-  const offers = product.offers.map((offer) => {
-    const totalPrice = offer.price + (offer.shippingFee ?? 0);
-
-    return {
-      id: offer.id,
-      price: offer.price,
-      totalPrice,
-      currency: offer.currency,
-      shippingFee: offer.shippingFee,
-      isAvailable: offer.isAvailable,
-      url: offer.url,
-      merchant: {
-        id: offer.merchant.id,
-        name: offer.merchant.name,
-        url: offer.merchant.url,
-        logoUrl: offer.merchant.logoUrl,
-        city: offer.merchant.city,
-      },
-      createdAt: offer.createdAt.toISOString(),
-      updatedAt: offer.updatedAt.toISOString(),
-    };
-  });
-
-  const offerTotals = offers.map((offer) => offer.totalPrice);
-  const minPrice = offers.length ? Math.min(...offers.map((offer) => offer.price)) : 0;
-  const maxPrice = offers.length ? Math.max(...offers.map((offer) => offer.price)) : 0;
-  const minTotalPrice = offerTotals.length ? Math.min(...offerTotals) : 0;
-
-  return {
-    id: product.id,
-    name: product.name,
-    slug: product.slug,
-    brand: product.brand,
-    model: product.model,
-    category: product.category,
-    categorySlug: product.categorySlug,
-    images: product.images,
-    minPrice,
-    maxPrice,
-    minTotalPrice,
-    offersCount: offers.length,
-    specifications: product.specifications,
-    createdAt: product.createdAt.toISOString(),
-    offers,
-  };
-};
-
-const loadProducts = async (where?: Prisma.ProductWhereInput) => {
-  const products = await prisma.product.findMany({
-    where,
-    include: {
-      offers: {
-        include: {
-          merchant: true,
-        },
-      },
-    },
-    orderBy: { createdAt: 'desc' },
-  });
-
-  return products.map(formatProductResponse);
-};
 
 app.use(cors());
 app.use(express.json());
 
-app.get('/api/health', (req, res) => {
+const sortProducts = (products: AggregatedProduct[], sortBy: string) => {
+  const sorted = [...products];
+  switch (sortBy) {
+    case 'price_asc':
+      return sorted.sort((a, b) => (a.minTotalPrice || a.minPrice) - (b.minTotalPrice || b.minPrice));
+    case 'price_desc':
+      return sorted.sort((a, b) => (b.minTotalPrice || b.minPrice) - (a.minTotalPrice || a.minPrice));
+    case 'name':
+      return sorted.sort((a, b) => a.name.localeCompare(b.name));
+    default:
+      return sorted;
+  }
+};
+
+app.get('/api/health', (_req, res) => {
   res.json({ status: 'OK', message: 'Atlas Taman GPT API 🚀' });
 });
 
 app.get('/api/search', async (req, res) => {
   try {
-    const { q, sortBy = 'relevance' } = req.query;
-    const searchTerm = typeof q === 'string' ? q.trim() : '';
+    const { q = '', sortBy = 'relevance' } = req.query;
+    const query = typeof q === 'string' ? q : '';
+    const sortParam = typeof sortBy === 'string' ? sortBy : 'relevance';
 
-    const where: Prisma.ProductWhereInput | undefined = searchTerm
-      ? {
-          OR: [
-            { name: { contains: searchTerm, mode: 'insensitive' } },
-            { brand: { contains: searchTerm, mode: 'insensitive' } },
-            { category: { contains: searchTerm, mode: 'insensitive' } },
-          ],
-        }
-      : undefined;
-
-    const products = await loadProducts(where);
-
-    const sortedProducts = [...products];
-
-    if (sortBy === 'price_asc') {
-      sortedProducts.sort((a, b) => (a.minTotalPrice ?? a.minPrice) - (b.minTotalPrice ?? b.minPrice));
-    } else if (sortBy === 'price_desc') {
-      sortedProducts.sort((a, b) => (b.minTotalPrice ?? b.minPrice) - (a.minTotalPrice ?? a.minPrice));
-    } else if (sortBy === 'name') {
-      sortedProducts.sort((a, b) => a.name.localeCompare(b.name));
-    }
+    const { products, errors, metadata } = await productAggregator.search(query);
+    const sortedProducts = sortProducts(products, sortParam);
 
     res.json({
       success: true,
-      data: { results: sortedProducts, pagination: { total: sortedProducts.length } },
+      data: {
+        results: sortedProducts,
+        pagination: { total: sortedProducts.length },
+        errors,
+        metadata,
+      },
     });
   } catch (error) {
     console.error('Erreur lors de la recherche de produits', error);
@@ -121,27 +53,23 @@ app.get('/api/search', async (req, res) => {
   }
 });
 
-app.get('/api/products', async (req, res) => {
+app.get('/api/products', async (_req, res) => {
   try {
-    const products = await loadProducts();
-
-    res.json({ success: true, data: { products } });
+    const { products, errors, metadata } = await productAggregator.listProducts();
+    res.json({ success: true, data: { products, errors, metadata } });
   } catch (error) {
     console.error('Erreur lors de la récupération des produits', error);
     res.status(500).json({ success: false, error: 'Impossible de charger les produits.' });
   }
 });
 
-const server = app.listen(PORT, () => {
-  console.log(`🚀 API Atlas Taman GPT sur le port ${PORT}`);
-  console.log(`🔍 Search: http://localhost:${PORT}/api/search?q=iphone`);
-});
+let server: ReturnType<typeof app.listen> | undefined;
 
-const shutdown = async () => {
-  console.log('👋 Arrêt du serveur, fermeture de la connexion Prisma...');
-  await prisma.$disconnect();
-  server.close(() => process.exit(0));
-};
+if (process.env.NODE_ENV !== 'test') {
+  server = app.listen(PORT, () => {
+    console.log(`🚀 API Atlas Taman GPT sur le port ${PORT}`);
+    console.log(`🔍 Search: http://localhost:${PORT}/api/search?q=iphone`);
+  });
+}
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+export { app, server };

--- a/backend/src/services/__tests__/productAggregator.test.ts
+++ b/backend/src/services/__tests__/productAggregator.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ProductAggregator } from '../productAggregator';
+import type { MerchantIntegration, MerchantOffer, MerchantProfile } from '../../integrations';
+
+const createOffer = (overrides: Partial<MerchantOffer> = {}): MerchantOffer => {
+  const merchant: MerchantProfile = overrides.merchant ?? {
+    id: 'merchant-a',
+    name: 'Merchant A',
+    url: 'https://merchant-a.example',
+  };
+
+  return {
+    offerId: `${merchant.id}-${overrides.productId ?? 'product-1'}`,
+    merchant,
+    productId: overrides.productId ?? 'product-1',
+    slug: overrides.slug ?? 'product-1',
+    title: overrides.title ?? 'Produit Test',
+    brand: overrides.brand ?? 'TestBrand',
+    category: overrides.category ?? 'Catégorie Test',
+    image: overrides.image ?? 'https://example.com/image.jpg',
+    price: overrides.price ?? 1000,
+    currency: overrides.currency ?? 'MAD',
+    shippingFee: overrides.shippingFee,
+    availability: overrides.availability ?? 'in_stock',
+    url: overrides.url ?? 'https://merchant-a.example/product-1',
+    scrapedAt: overrides.scrapedAt ?? new Date().toISOString(),
+  };
+};
+
+const createIntegration = (
+  id: string,
+  offers: MerchantOffer[] | (() => Promise<MerchantOffer[]>)
+): MerchantIntegration => ({
+  id,
+  label: id,
+  profile: {
+    id,
+    name: id,
+    url: `https://${id}.example`,
+  },
+  async search() {
+    if (typeof offers === 'function') {
+      return offers();
+    }
+    return offers;
+  },
+});
+
+const now = new Date().toISOString();
+
+test('normalises offers from multiple merchants', async () => {
+  const integrationA = createIntegration('merchant-a', [
+    createOffer({
+      productId: 'iphone-15-pro',
+      slug: 'iphone-15-pro',
+      title: 'Apple iPhone 15 Pro',
+      brand: 'Apple',
+      category: 'Smartphones',
+      price: 12345,
+      shippingFee: 0,
+      scrapedAt: now,
+    }),
+  ]);
+
+  const integrationB = createIntegration('merchant-b', [
+    createOffer({
+      merchant: { id: 'merchant-b', name: 'Merchant B', url: 'https://merchant-b.example' },
+      productId: 'iphone-15-pro-256',
+      slug: 'iphone-15-pro',
+      title: 'Apple iPhone 15 Pro 256GB',
+      brand: 'Apple',
+      category: 'Smartphones',
+      price: 12999,
+      shippingFee: 199,
+      scrapedAt: now,
+      url: 'https://merchant-b.example/iphone-15-pro',
+    }),
+  ]);
+
+  const aggregator = new ProductAggregator({
+    integrations: [integrationA, integrationB],
+    cacheTtlMs: 1000,
+    rateLimitMs: 0,
+  });
+
+  const { products, errors, metadata } = await aggregator.search('iphone');
+
+  assert.equal(errors.length, 0);
+  assert.equal(metadata.fromCache, false);
+  assert.equal(products.length, 1);
+
+  const product = products[0];
+  assert.equal(product.slug, 'iphone-15-pro');
+  assert.equal(product.minPrice, 12345);
+  assert.equal(product.maxPrice, 12999);
+  assert.equal(product.minTotalPrice, 12345);
+  assert.equal(product.offersCount, 2);
+  assert.equal(product.offers[0].merchant.name, 'Merchant A');
+  assert.equal(product.offers[1].totalPrice, 12999 + 199);
+});
+
+test('returns cached data on subsequent calls', async () => {
+  let calls = 0;
+  const integration = createIntegration('merchant-cache', async () => {
+    calls += 1;
+    return [createOffer({ title: 'Produit Cache' })];
+  });
+
+  const aggregator = new ProductAggregator({
+    integrations: [integration],
+    cacheTtlMs: 10_000,
+    rateLimitMs: 0,
+  });
+
+  const first = await aggregator.search('cache test');
+  assert.equal(first.metadata.fromCache, false);
+  assert.equal(calls, 1);
+
+  const second = await aggregator.search('cache test');
+  assert.equal(second.metadata.fromCache, true);
+  assert.equal(calls, 1);
+});
+
+test('captures integration errors without stopping other connectors', async () => {
+  const failingIntegration: MerchantIntegration = {
+    id: 'failing',
+    label: 'Failing',
+    profile: { id: 'failing', name: 'Failing', url: 'https://failing.example' },
+    async search() {
+      throw new Error('Timeout');
+    },
+  };
+
+  const healthyIntegration = createIntegration('healthy', [
+    createOffer({
+      merchant: { id: 'healthy', name: 'Healthy', url: 'https://healthy.example' },
+      productId: 'ps5-slim',
+      slug: 'playstation-5-slim',
+      title: 'PlayStation 5 Slim',
+      category: 'Gaming',
+      price: 5999,
+      scrapedAt: now,
+    }),
+  ]);
+
+  const aggregator = new ProductAggregator({
+    integrations: [failingIntegration, healthyIntegration],
+    cacheTtlMs: 1000,
+    rateLimitMs: 0,
+  });
+
+  const { products, errors, metadata } = await aggregator.search('ps5');
+
+  assert.equal(metadata.integrations.length, 2);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].merchantId, 'failing');
+  assert.equal(products.length, 1);
+  assert.equal(products[0].slug, 'playstation-5-slim');
+});

--- a/backend/src/services/productAggregator.ts
+++ b/backend/src/services/productAggregator.ts
@@ -1,0 +1,306 @@
+import LRUCache from 'lru-cache';
+import pLimit, { type Limit } from 'p-limit';
+import { createDefaultIntegrations, MerchantIntegration, MerchantOffer, MerchantProfile } from '../integrations';
+import { normalizeQuery } from '../integrations/utils';
+
+export interface AggregatedOffer {
+  id: string;
+  price: number;
+  totalPrice: number;
+  currency: string;
+  shippingFee?: number | null;
+  isAvailable: boolean;
+  url: string;
+  merchant: MerchantProfile;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AggregatedProduct {
+  id: string;
+  name: string;
+  slug: string;
+  brand?: string;
+  model?: string;
+  category: string;
+  categorySlug: string;
+  images: string[];
+  minPrice: number;
+  maxPrice: number;
+  minTotalPrice: number;
+  offersCount: number;
+  offers: AggregatedOffer[];
+  specifications: Record<string, string>;
+  createdAt: string;
+}
+
+export interface IntegrationMetric {
+  id: string;
+  label: string;
+  durationMs: number;
+  offers: number;
+  status: 'fulfilled' | 'rejected';
+  error?: string;
+}
+
+export interface IntegrationError {
+  merchantId: string;
+  merchantName: string;
+  message: string;
+}
+
+export interface AggregationMetadata {
+  query: string;
+  fromCache: boolean;
+  tookMs: number;
+  generatedAt: string;
+  integrations: IntegrationMetric[];
+}
+
+export interface AggregationResponse {
+  products: AggregatedProduct[];
+  errors: IntegrationError[];
+  metadata: AggregationMetadata;
+}
+
+interface AggregatedProductBuilder {
+  id: string;
+  slug: string;
+  name: string;
+  brand?: string;
+  category?: string;
+  images: Set<string>;
+  offers: AggregatedOffer[];
+  createdAt: string;
+}
+
+interface IntegrationExecutionResult {
+  offers: MerchantOffer[];
+  metric: IntegrationMetric;
+  error?: IntegrationError;
+}
+
+const deepClone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const slugify = (input: string) =>
+  input
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+
+const isValidOffer = (offer: MerchantOffer) =>
+  offer.price > 0 && offer.availability !== 'out_of_stock';
+
+const toAggregatedOffer = (offer: MerchantOffer): AggregatedOffer => {
+  const shippingFee = offer.shippingFee ?? null;
+  const totalPrice = offer.price + (shippingFee ?? 0);
+  return {
+    id: offer.offerId,
+    price: offer.price,
+    totalPrice,
+    currency: offer.currency,
+    shippingFee,
+    isAvailable: offer.availability !== 'out_of_stock',
+    url: offer.url,
+    merchant: offer.merchant,
+    createdAt: offer.scrapedAt,
+    updatedAt: offer.scrapedAt,
+  };
+};
+
+export interface ProductAggregatorOptions {
+  cacheTtlMs?: number;
+  rateLimitMs?: number;
+  maxConcurrency?: number;
+  integrations?: MerchantIntegration[];
+}
+
+export class ProductAggregator {
+  private readonly integrations: MerchantIntegration[];
+  private readonly cache: LRUCache<string, AggregationResponse>;
+  private readonly lastInvocation = new Map<string, number>();
+  private readonly rateLimitMs: number;
+  private readonly limiter: Limit;
+
+  constructor(options: ProductAggregatorOptions = {}) {
+    this.integrations = options.integrations ?? createDefaultIntegrations();
+    const cacheTtlMs = options.cacheTtlMs ?? 1000 * 60 * 5;
+    this.cache = new LRUCache({ max: 50, ttl: cacheTtlMs });
+    this.rateLimitMs = options.rateLimitMs ?? 500;
+    const maxConcurrency = options.maxConcurrency ?? 3;
+    this.limiter = pLimit(maxConcurrency);
+  }
+
+  async search(query: string): Promise<AggregationResponse> {
+    const normalizedQuery = normalizeQuery(query ?? '');
+    const cacheKey = `search:${normalizedQuery || '__all__'}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      const response = deepClone(cached);
+      response.metadata.fromCache = true;
+      return response;
+    }
+
+    const startedAt = Date.now();
+    const offers: MerchantOffer[] = [];
+    const errors: IntegrationError[] = [];
+    const metrics: IntegrationMetric[] = [];
+
+    const tasks = this.integrations.map((integration) =>
+      this.limiter(() => this.executeIntegration(integration, normalizedQuery))
+    );
+
+    const results = await Promise.all(tasks);
+    for (const result of results) {
+      offers.push(...result.offers);
+      metrics.push(result.metric);
+      if (result.error) {
+        errors.push(result.error);
+      }
+    }
+
+    const products = this.normalizeOffers(offers);
+    const tookMs = Date.now() - startedAt;
+    const response: AggregationResponse = {
+      products,
+      errors,
+      metadata: {
+        query: normalizedQuery,
+        fromCache: false,
+        tookMs,
+        generatedAt: new Date().toISOString(),
+        integrations: metrics,
+      },
+    };
+
+    this.cache.set(cacheKey, deepClone(response));
+    return response;
+  }
+
+  async listProducts(): Promise<AggregationResponse> {
+    return this.search('');
+  }
+
+  private async executeIntegration(
+    integration: MerchantIntegration,
+    query: string
+  ): Promise<IntegrationExecutionResult> {
+    const startedAt = Date.now();
+    await this.applyRateLimit(integration.id);
+
+    try {
+      const offers = await integration.search(query);
+      const filteredOffers = offers.filter(isValidOffer);
+      const durationMs = Date.now() - startedAt;
+      return {
+        offers: filteredOffers,
+        metric: {
+          id: integration.id,
+          label: integration.label,
+          durationMs,
+          offers: filteredOffers.length,
+          status: 'fulfilled' as const,
+        },
+      };
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const message = error instanceof Error ? error.message : 'Erreur inconnue';
+      return {
+        offers: [] as MerchantOffer[],
+        metric: {
+          id: integration.id,
+          label: integration.label,
+          durationMs,
+          offers: 0,
+          status: 'rejected' as const,
+          error: message,
+        },
+        error: {
+          merchantId: integration.id,
+          merchantName: integration.label,
+          message,
+        },
+      };
+    }
+  }
+
+  private async applyRateLimit(merchantId: string) {
+    const now = Date.now();
+    const lastCall = this.lastInvocation.get(merchantId) ?? 0;
+    const delta = now - lastCall;
+    if (delta < this.rateLimitMs) {
+      await new Promise((resolve) => setTimeout(resolve, this.rateLimitMs - delta));
+    }
+    this.lastInvocation.set(merchantId, Date.now());
+  }
+
+  private normalizeOffers(offers: MerchantOffer[]): AggregatedProduct[] {
+    const products = new Map<string, AggregatedProductBuilder>();
+
+    for (const offer of offers) {
+      if (!isValidOffer(offer)) {
+        continue;
+      }
+
+      const slug = slugify(offer.slug || offer.title);
+      if (!slug) {
+        continue;
+      }
+
+      let builder = products.get(slug);
+      if (!builder) {
+        builder = {
+          id: slug,
+          slug,
+          name: offer.title,
+          brand: offer.brand,
+          category: offer.category,
+          images: new Set<string>(),
+          offers: [],
+          createdAt: offer.scrapedAt,
+        };
+        products.set(slug, builder);
+      }
+
+      builder.name = builder.name || offer.title;
+      builder.brand = builder.brand ?? offer.brand;
+      builder.category = builder.category ?? offer.category;
+      if (offer.image) {
+        builder.images.add(offer.image);
+      }
+      builder.createdAt = builder.createdAt < offer.scrapedAt ? builder.createdAt : offer.scrapedAt;
+      builder.offers.push(toAggregatedOffer(offer));
+    }
+
+    const aggregated: AggregatedProduct[] = [];
+    for (const builder of products.values()) {
+      const offersSorted = [...builder.offers].sort((a, b) => a.totalPrice - b.totalPrice);
+      const prices = offersSorted.map((offer) => offer.price);
+      const minPrice = prices.length ? Math.min(...prices) : 0;
+      const maxPrice = prices.length ? Math.max(...prices) : 0;
+      const minTotalPrice = offersSorted.length ? offersSorted[0].totalPrice : 0;
+      aggregated.push({
+        id: builder.id,
+        name: builder.name,
+        slug: builder.slug,
+        brand: builder.brand,
+        category: builder.category ?? 'Divers',
+        categorySlug: slugify(builder.category ?? 'Divers'),
+        images: Array.from(builder.images),
+        minPrice,
+        maxPrice,
+        minTotalPrice,
+        offersCount: offersSorted.length,
+        offers: offersSorted,
+        specifications: {},
+        createdAt: builder.createdAt,
+      });
+    }
+
+    return aggregated.sort((a, b) => a.minTotalPrice - b.minTotalPrice || a.name.localeCompare(b.name));
+  }
+}
+
+export const productAggregator = new ProductAggregator();

--- a/backend/src/types/lru-cache.d.ts
+++ b/backend/src/types/lru-cache.d.ts
@@ -1,0 +1,13 @@
+declare module 'lru-cache' {
+  export interface LRUCacheOptions<K, V> {
+    max?: number;
+    ttl?: number;
+  }
+
+  export default class LRUCache<K, V> {
+    constructor(options?: LRUCacheOptions<K, V>);
+    get(key: K): V | undefined;
+    set(key: K, value: V): this;
+    has(key: K): boolean;
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "CommonJS",
     "rootDir": "./src",
     "outDir": "./dist",
+    "resolveJsonModule": true,
+    "types": ["node"],
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true

--- a/frontend/src/components/product/ProductCard.tsx
+++ b/frontend/src/components/product/ProductCard.tsx
@@ -15,16 +15,19 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, showDiscount 
     }).format(price);
   };
 
-  const discount = showDiscount && product.maxPrice > product.minPrice
-    ? Math.round(((product.maxPrice - product.minPrice) / product.maxPrice) * 100)
-    : 0;
+  const discount =
+    showDiscount && product.maxPrice > product.minPrice
+      ? Math.round(((product.maxPrice - product.minPrice) / product.maxPrice) * 100)
+      : 0;
 
-  const bestOffer = product.offers && product.offers.length > 0
+  const bestOffer = product.offers.length
     ? product.offers.reduce((best, offer) => {
         const bestTotal = best ? best.totalPrice : Number.POSITIVE_INFINITY;
         return offer.totalPrice < bestTotal ? offer : best;
       }, product.offers[0])
     : undefined;
+
+  const displayedOffers = product.offers.slice(0, 3);
 
   return (
     <div className="bg-white rounded-lg shadow-md hover:shadow-xl transition-all duration-300 cursor-pointer overflow-hidden group">
@@ -63,29 +66,53 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, showDiscount 
             <span className="text-sm text-gray-400 line-through">{formatPrice(product.maxPrice)}</span>
           )}
         </div>
-        <div className="space-y-2 text-xs text-gray-600 mb-3">
+        <div className="space-y-3 text-xs text-gray-600 mb-3">
           <div className="flex items-center justify-between">
-            <span>🏪 {product.offersCount} {product.offersCount > 1 ? 'offres' : 'offre'}</span>
+            <span>
+              🏪 {product.offersCount} {product.offersCount > 1 ? 'offres' : 'offre'}
+            </span>
             {bestOffer?.merchant?.name && (
               <span className="text-gray-500">Meilleur prix : {bestOffer.merchant.name}</span>
             )}
           </div>
-          {bestOffer && (
-            <div className="flex items-center justify-between">
-              <span>🚚 Livraison</span>
-              <span className="text-gray-700">
-                {bestOffer.shippingFee != null
-                  ? bestOffer.shippingFee > 0
-                    ? `${formatPrice(bestOffer.shippingFee)} supplémentaires`
-                    : 'Offerte'
-                  : 'NC'}
-              </span>
-            </div>
-          )}
+          <div className="space-y-1">
+            {displayedOffers.map((offer) => (
+              <a
+                key={offer.id}
+                href={offer.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between rounded-md bg-gray-50 hover:bg-gray-100 transition-colors px-3 py-2"
+              >
+                <div>
+                  <p className="font-medium text-gray-700">{offer.merchant.name}</p>
+                  <p className="text-[11px] text-gray-500">
+                    {offer.shippingFee != null
+                      ? offer.shippingFee > 0
+                        ? `+ ${formatPrice(offer.shippingFee)} de livraison`
+                        : 'Livraison offerte'
+                      : 'Livraison NC'}
+                  </p>
+                </div>
+                <span className="text-sm font-semibold text-gray-900">{formatPrice(offer.totalPrice)}</span>
+              </a>
+            ))}
+            {product.offers.length > displayedOffers.length && (
+              <p className="text-[11px] text-gray-500">+ {product.offers.length - displayedOffers.length} autres offres disponibles</p>
+            )}
+          </div>
         </div>
-        <button className="w-full bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors">
-          Voir les offres
-        </button>
+        <a
+          href={bestOffer?.url ?? '#'}
+          target={bestOffer ? '_blank' : undefined}
+          rel={bestOffer ? 'noopener noreferrer' : undefined}
+          className={`w-full block text-center py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+            bestOffer ? 'bg-blue-600 text-white hover:bg-blue-700' : 'bg-gray-200 text-gray-500 cursor-not-allowed'
+          }`}
+          aria-disabled={!bestOffer}
+        >
+          {bestOffer ? 'Voir la meilleure offre' : 'Aucune offre disponible'}
+        </a>
       </div>
     </div>
   );

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,12 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { ProductCard } from '../components/product/ProductCard';
-import { Product } from '../types';
+import { Product, IntegrationError, SearchMetadata } from '../types';
 
 export const SearchPage: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState('relevance');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [integrationErrors, setIntegrationErrors] = useState<IntegrationError[]>([]);
+  const [metadata, setMetadata] = useState<SearchMetadata | null>(null);
+  const [slowResponse, setSlowResponse] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -22,17 +26,39 @@ export const SearchPage: React.FC = () => {
     if (!trimmedQuery) {
       setProducts([]);
       setLoading(false);
+      setIntegrationErrors([]);
+      setMetadata(null);
+      setErrorMessage(null);
       return;
     }
 
     setLoading(true);
+    setSlowResponse(false);
+    setErrorMessage(null);
+    setIntegrationErrors([]);
+    setMetadata(null);
+    const slowTimer = window.setTimeout(() => setSlowResponse(true), 1200);
     try {
       const response = await fetch(`/api/search?q=${encodeURIComponent(trimmedQuery)}&sortBy=${sortParam}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
       const data = await response.json();
-      if (data.success) setProducts(data.data.results || []);
+      if (data.success) {
+        setProducts(data.data.results || []);
+        setIntegrationErrors(data.data.errors || []);
+        setMetadata(data.data.metadata || null);
+      } else {
+        setProducts([]);
+        setErrorMessage(data.error || 'La recherche a échoué.');
+      }
     } catch (error) {
       console.error('Erreur de recherche:', error);
+      setProducts([]);
+      setErrorMessage("Nous n'avons pas pu contacter les marchands. Veuillez réessayer plus tard.");
     } finally {
+      window.clearTimeout(slowTimer);
+      setSlowResponse(false);
       setLoading(false);
     }
   };
@@ -43,19 +69,32 @@ export const SearchPage: React.FC = () => {
         <div className="text-center">
           <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-gray-600">Recherche en cours...</p>
+          {slowResponse && (
+            <p className="text-xs text-gray-500 mt-2">Certains marchands prennent un peu plus de temps à répondre…</p>
+          )}
         </div>
       </div>
     );
   }
 
+  const successfulIntegrations = metadata?.integrations.filter((item) => item.status === 'fulfilled').length ?? 0;
+  const totalIntegrations = metadata?.integrations.length ?? 0;
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white shadow">
         <div className="max-w-7xl mx-auto py-4 px-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between flex-wrap gap-4">
             <div>
               <h1 className="text-2xl font-bold text-gray-900">Résultats pour "{searchQuery}"</h1>
               <p className="text-sm text-gray-600 mt-1">{products.length} produits trouvés</p>
+              {metadata && (
+                <p className="text-xs text-gray-500 mt-1">
+                  {metadata.fromCache ? 'Résultats servis depuis le cache' : 'Résultats actualisés'} •
+                  {` ${successfulIntegrations}/${totalIntegrations} marchands`} •
+                  {` ${Math.round(metadata.tookMs)} ms`}
+                </p>
+              )}
             </div>
             <select
               value={sortBy}
@@ -75,13 +114,25 @@ export const SearchPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto py-6 px-4">
+      <div className="max-w-7xl mx-auto py-6 px-4 space-y-4">
+        {errorMessage && (
+          <div className="bg-red-50 text-red-700 border border-red-200 px-4 py-3 rounded-md">
+            {errorMessage}
+          </div>
+        )}
+
+        {!errorMessage && integrationErrors.length > 0 && (
+          <div className="bg-amber-50 border border-amber-200 px-4 py-3 rounded-md text-amber-800 text-sm">
+            Certaines intégrations n'ont pas répondu : {integrationErrors.map((error) => error.merchantName).join(', ')}.
+          </div>
+        )}
+
         {products.length === 0 ? (
           <div className="bg-white rounded-lg shadow p-12 text-center">
             <div className="text-6xl mb-4">🔍</div>
             <h3 className="text-xl font-semibold text-gray-900 mb-2">Aucun produit trouvé</h3>
             <button
-              onClick={() => window.location.href = '/'}
+              onClick={() => (window.location.href = '/')}
               className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 mt-4"
             >
               Retour à l'accueil

--- a/frontend/src/pages/__tests__/SearchPage.test.tsx
+++ b/frontend/src/pages/__tests__/SearchPage.test.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { SearchPage } from '../SearchPage';
 
@@ -7,58 +6,113 @@ const originalFetch = global.fetch;
 
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-describe('SearchPage sorting behaviour', () => {
+const baseMetadata = {
+  query: 'ordinateur',
+  fromCache: false,
+  tookMs: 120,
+  generatedAt: '2024-01-01T00:00:00Z',
+  integrations: [],
+};
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface TestOffer {
+  id: string;
+  price: number;
+  totalPrice: number;
+  currency: string;
+  shippingFee: number;
+  isAvailable: boolean;
+  url: string;
+  merchant: { id: string; name: string; url: string };
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface TestProduct {
+  id: string;
+  name: string;
+  slug: string;
+  brand?: string;
+  category: string;
+  categorySlug: string;
+  images: string[];
+  minPrice: number;
+  maxPrice: number;
+  minTotalPrice: number;
+  offersCount: number;
+  offers: TestOffer[];
+  specifications: Record<string, never>;
+  createdAt: string;
+}
+
+function createProduct(overrides: Partial<TestProduct> = {}): TestProduct {
+  const baseOffer: TestOffer = {
+    id: `${overrides.id ?? 'produit-a'}-offer`,
+    price: overrides.minPrice ?? 100,
+    totalPrice: overrides.minTotalPrice ?? 110,
+    currency: 'MAD',
+    shippingFee: (overrides.minTotalPrice ?? 110) - (overrides.minPrice ?? 100),
+    isAvailable: true,
+    url: `https://example.com/${overrides.slug ?? 'produit-a'}`,
+    merchant: { id: 'merchant-a', name: 'Marchand A', url: 'https://example.com' },
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  };
+
+  const offers = overrides.offers ?? [baseOffer];
+
+  return {
+    id: 'produit-a',
+    name: 'Produit A',
+    slug: 'produit-a',
+    brand: 'Marque A',
+    category: 'Catégorie',
+    categorySlug: 'categorie',
+    images: [],
+    minPrice: 100,
+    maxPrice: 150,
+    minTotalPrice: 110,
+    offersCount: offers.length,
+    offers,
+    specifications: {},
+    createdAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+    offers,
+    offersCount: offers.length,
+  };
+}
+
+describe('SearchPage data flow', () => {
   const mockFetch = jest.fn();
 
   beforeEach(() => {
     mockFetch.mockReset();
     (global as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+    window.history.replaceState({}, '', '/');
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    window.history.replaceState({}, '', '/');
     document.body.innerHTML = '';
   });
 
   it('appends the selected sort to the request and updates product order', async () => {
     const initialResults = [
-      {
-        id: 1,
-        name: 'Produit A',
-        slug: 'produit-a',
-        brand: 'Marque A',
-        category: 'Catégorie',
-        categorySlug: 'categorie',
-        images: [],
-        minPrice: 100,
-        maxPrice: 150,
-        offersCount: 2,
-        createdAt: '2024-01-01T00:00:00Z',
-      },
-      {
-        id: 2,
-        name: 'Produit B',
-        slug: 'produit-b',
-        brand: 'Marque B',
-        category: 'Catégorie',
-        categorySlug: 'categorie',
-        images: [],
-        minPrice: 200,
-        maxPrice: 250,
-        offersCount: 3,
-        createdAt: '2024-01-02T00:00:00Z',
-      },
+      createProduct({ id: 'produit-a', name: 'Produit A', slug: 'produit-a', minPrice: 100, minTotalPrice: 110 }),
+      createProduct({ id: 'produit-b', name: 'Produit B', slug: 'produit-b', minPrice: 200, minTotalPrice: 210 }),
     ];
 
     const sortedResults = [...initialResults].reverse();
 
     mockFetch
       .mockResolvedValueOnce({
-        json: async () => ({ success: true, data: { results: initialResults } }),
+        ok: true,
+        json: async () => ({ success: true, data: { results: initialResults, pagination: { total: 2 }, errors: [], metadata: baseMetadata } }),
       } as Response)
       .mockResolvedValueOnce({
-        json: async () => ({ success: true, data: { results: sortedResults } }),
+        ok: true,
+        json: async () => ({ success: true, data: { results: sortedResults, pagination: { total: 2 }, errors: [], metadata: baseMetadata } }),
       } as Response);
 
     window.history.pushState({}, '', '/search?q=ordinateur');
@@ -91,10 +145,63 @@ describe('SearchPage sorting behaviour', () => {
     expect(mockFetch.mock.calls[1][0]).toContain('sortBy=price_desc');
 
     const headings = Array.from(container.querySelectorAll('h3'));
-    expect(headings.map((heading) => heading.textContent)).toEqual([
-      'Produit B',
-      'Produit A',
-    ]);
+    expect(headings.map((heading) => heading.textContent)).toEqual(['Produit B', 'Produit A']);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('displays integration errors returned by the API', async () => {
+    const responsePayload = {
+      success: true,
+      data: {
+        results: [createProduct()],
+        pagination: { total: 1 },
+        errors: [{ merchantId: 'jumia', merchantName: 'Jumia', message: 'Timeout' }],
+        metadata: baseMetadata,
+      },
+    };
+
+    mockFetch.mockResolvedValue({ ok: true, json: async () => responsePayload } as Response);
+
+    window.history.pushState({}, '', '/search?q=ordinateur');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchPage />);
+      await flushPromises();
+    });
+
+    const warning = container.querySelector('.bg-amber-50');
+    expect(warning?.textContent).toContain("Jumia");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows an error banner when the request fails', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    window.history.pushState({}, '', '/search?q=ordinateur');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchPage />);
+      await flushPromises();
+    });
+
+    const alert = container.querySelector('.bg-red-50');
+    expect(alert?.textContent).toContain('Veuillez réessayer');
 
     await act(async () => {
       root.unmount();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,40 +1,63 @@
 export interface Merchant {
-  id: number;
+  id: string;
   name: string;
-  url?: string | null;
+  url: string;
   logoUrl?: string | null;
   city?: string | null;
 }
 
 export interface Offer {
-  id: number;
+  id: string;
   price: number;
   totalPrice: number;
   currency: string;
   shippingFee?: number | null;
   isAvailable: boolean;
-  url?: string | null;
+  url: string;
   merchant: Merchant;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface Product {
-  id: number;
+  id: string;
   name: string;
   slug: string;
-  brand: string;
+  brand?: string;
   model?: string;
   category: string;
   categorySlug: string;
   images: string[];
   minPrice: number;
   maxPrice: number;
-  minTotalPrice?: number;
+  minTotalPrice: number;
   offersCount: number;
-  offers?: Offer[];
-  specifications?: Record<string, any>;
+  offers: Offer[];
+  specifications?: Record<string, string>;
   createdAt: string;
+}
+
+export interface IntegrationMetric {
+  id: string;
+  label: string;
+  durationMs: number;
+  offers: number;
+  status: 'fulfilled' | 'rejected';
+  error?: string;
+}
+
+export interface IntegrationError {
+  merchantId: string;
+  merchantName: string;
+  message: string;
+}
+
+export interface SearchMetadata {
+  query: string;
+  fromCache: boolean;
+  tookMs: number;
+  generatedAt: string;
+  integrations: IntegrationMetric[];
 }
 
 export interface SearchFilters {


### PR DESCRIPTION
## Summary
- add fixture-driven integrations for Electroplanet, Jumia, Marjane, BIM, Decathlon, and H&M with shared parsing utilities
- build a product aggregator service with caching/rate limiting and switch the Express API to serve aggregated search/catalogue data
- update the React search experience to surface integration status, merchant offer links, and new type definitions with unit/integration tests across the stack

## Testing
- `npm --prefix backend test`
- `CI=1 npm --prefix frontend test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68dbbfaeefc8832582a9dc9815ce7c3f