### PR TITLE
feat: implement live merchant integrations

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "htmlparser2": "^6.1.0",
     "lru-cache": "^10.2.0",
     "p-limit": "^4.0.0"
   },

--- a/backend/src/integrations/bim.ts
+++ b/backend/src/integrations/bim.ts
@@ -1,0 +1,9 @@
+import { createProductCardIntegration } from './utils';
+
+export const bimIntegration = createProductCardIntegration({
+  merchantId: 'bim',
+  label: 'BIM',
+  defaultSearchUrl: 'https://www.bim.ma/recherche',
+  defaultQueryParam: 'query',
+  defaultCurrency: 'MAD',
+});

--- a/backend/src/integrations/decathlon.ts
+++ b/backend/src/integrations/decathlon.ts
@@ -1,0 +1,9 @@
+import { createProductCardIntegration } from './utils';
+
+export const decathlonIntegration = createProductCardIntegration({
+  merchantId: 'decathlon',
+  label: 'Decathlon',
+  defaultSearchUrl: 'https://www.decathlon.ma/search',
+  defaultQueryParam: 'q',
+  defaultCurrency: 'MAD',
+});

--- a/backend/src/integrations/electroplanet.ts
+++ b/backend/src/integrations/electroplanet.ts
@@ -1,0 +1,9 @@
+import { createProductCardIntegration } from './utils';
+
+export const electroplanetIntegration = createProductCardIntegration({
+  merchantId: 'electroplanet',
+  label: 'Electroplanet',
+  defaultSearchUrl: 'https://www.electroplanet.ma/catalogsearch/result/',
+  defaultQueryParam: 'q',
+  defaultCurrency: 'MAD',
+});

--- a/backend/src/integrations/hm.ts
+++ b/backend/src/integrations/hm.ts
@@ -1,0 +1,9 @@
+import { createProductCardIntegration } from './utils';
+
+export const hmIntegration = createProductCardIntegration({
+  merchantId: 'hm',
+  label: 'H&M',
+  defaultSearchUrl: 'https://www2.hm.com/fr_ma/search-results.html',
+  defaultQueryParam: 'q',
+  defaultCurrency: 'MAD',
+});

--- a/backend/src/integrations/index.ts
+++ b/backend/src/integrations/index.ts
@@ -1,13 +1,24 @@
-import { createIntegrationFromFixtures } from './utils';
+import { bimIntegration } from './bim';
+import { decathlonIntegration } from './decathlon';
+import { electroplanetIntegration } from './electroplanet';
+import { hmIntegration } from './hm';
+import { jumiaIntegration } from './jumia';
+import { marjaneIntegration } from './marjane';
 import { MerchantIntegration } from './types';
 
 export const createDefaultIntegrations = (): MerchantIntegration[] => [
-  createIntegrationFromFixtures('electroplanet', 'Electroplanet', 'https://www.electroplanet.ma/catalogsearch/result/?q='),
-  createIntegrationFromFixtures('jumia', 'Jumia', 'https://www.jumia.ma/catalog/?q='),
-  createIntegrationFromFixtures('marjane', 'Marjane', 'https://www.marjane.ma/search?q='),
-  createIntegrationFromFixtures('bim', 'BIM', 'https://www.bim.ma/recherche?query='),
-  createIntegrationFromFixtures('decathlon', 'Decathlon', 'https://www.decathlon.ma/search?q='),
-  createIntegrationFromFixtures('hm', 'H&M', 'https://www2.hm.com/fr_ma/search-results.html?q='),
+  electroplanetIntegration,
+  jumiaIntegration,
+  marjaneIntegration,
+  bimIntegration,
+  decathlonIntegration,
+  hmIntegration,
 ];
 
 export * from './types';
+export * from './electroplanet';
+export * from './jumia';
+export * from './marjane';
+export * from './bim';
+export * from './decathlon';
+export * from './hm';

--- a/backend/src/integrations/jumia.ts
+++ b/backend/src/integrations/jumia.ts
@@ -1,0 +1,9 @@
+import { createProductCardIntegration } from './utils';
+
+export const jumiaIntegration = createProductCardIntegration({
+  merchantId: 'jumia',
+  label: 'Jumia',
+  defaultSearchUrl: 'https://www.jumia.ma/catalog/',
+  defaultQueryParam: 'q',
+  defaultCurrency: 'MAD',
+});

--- a/backend/src/integrations/marjane.ts
+++ b/backend/src/integrations/marjane.ts
@@ -1,0 +1,9 @@
+import { createProductCardIntegration } from './utils';
+
+export const marjaneIntegration = createProductCardIntegration({
+  merchantId: 'marjane',
+  label: 'Marjane',
+  defaultSearchUrl: 'https://www.marjane.ma/search',
+  defaultQueryParam: 'q',
+  defaultCurrency: 'MAD',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "htmlparser2": "^6.1.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",


### PR DESCRIPTION
## Summary
- rework integration utilities to support real HTTP scraping with htmlparser2, shared config parsing, and reusable rate limiting helpers
- add dedicated merchant modules for Electroplanet, Jumia, Marjane, BIM, Decathlon, and H&M and wire them into the default integration factory
- update the product aggregator and server tests to exercise live flows via mocked fetch responses and ensure API endpoints behave correctly

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dbc40404648325af895d9d8f9bc290