### PR TITLE
Refactor integrations to use merchant-specific parsers

### DIFF
--- a/backend/src/__tests__/server.test.ts
+++ b/backend/src/__tests__/server.test.ts
@@ -17,23 +17,110 @@ const previousEnvValues = merchantMocks.map(({ env }) => [env, process.env[env]]
 
 const responses = new Map<string, string>();
 
-const buildHtml = (merchantId: string, price: number, shippingFee: number) => `
-  <section class="catalog">
-    <article class="product-card"
-      data-product-id="${merchantId}-iphone"
-      data-product-slug="iphone-15-pro"
-      data-product-url="/${merchantId}/iphone-15-pro"
-      data-price="${price}"
-      data-currency="MAD"
-      data-shipping-fee="${shippingFee}"
-      data-availability="in_stock">
-      <h3 class="product-title">Apple iPhone 15 Pro</h3>
-      <span class="product-brand">Apple</span>
-      <span class="product-category">Smartphones</span>
-      <img src="https://static.${merchantId}.test/iphone.jpg" alt="Apple iPhone 15 Pro" />
-    </article>
-  </section>
-`;
+const buildHtml = (merchantId: string, price: number, shippingFee: number) => {
+  const shippingText = shippingFee > 0 ? `Livraison ${shippingFee} MAD` : 'Livraison gratuite';
+
+  switch (merchantId) {
+    case 'electroplanet':
+      return `
+        <ul class="products list items">
+          <li class="item product product-item" data-product-id="${merchantId}-iphone" data-sku="iphone-15-pro" data-product-url="/${merchantId}/iphone-15-pro.html">
+            <div class="product-item-info" data-product-id="${merchantId}-iphone">
+              <a class="product-item-link" href="/${merchantId}/iphone-15-pro.html">
+                <span class="product name product-item-name">Apple iPhone 15 Pro</span>
+              </a>
+              <div class="product-brand">Apple</div>
+              <div class="product-category">Smartphones</div>
+              <div class="price-box">
+                <span class="price" data-price-currency="MAD">${price} DH</span>
+              </div>
+              <div class="shipping">${shippingText}</div>
+              <div class="stock available">Disponible</div>
+              <img class="product-image-photo" data-src="https://static.${merchantId}.test/iphone.jpg" />
+            </div>
+          </li>
+        </ul>
+      `;
+    case 'jumia':
+      return `
+        <section class="products">
+          <article class="prd _fb col c-prd" data-sku="${merchantId}-iphone" data-url="https://${merchantId}.test/iphone-15-pro" data-brand="Apple" data-category="Smartphones">
+            <a class="core" href="/${merchantId}/iphone-15-pro">
+              <div class="name">Apple iPhone 15 Pro 256GB</div>
+            </a>
+            <div class="prc">${price} DH</div>
+            <div class="shp">${shippingText}</div>
+            <div class="stk _available">En stock</div>
+            <img data-src="https://static.${merchantId}.test/iphone.jpg" />
+          </article>
+        </section>
+      `;
+    case 'marjane':
+      return `
+        <div class="product-list">
+          <div class="product-card" data-product-id="${merchantId}-iphone" data-sku="iphone-15-pro">
+            <a class="product-link" href="/${merchantId}/iphone-15-pro">
+              <h2 class="product-title">Apple iPhone 15 Pro</h2>
+            </a>
+            <div class="product-brand">Apple</div>
+            <div class="product-category">Smartphones</div>
+            <div class="price-amount">${price} MAD</div>
+            <div class="product-shipping">${shippingText}</div>
+            <div class="product-stock">Disponible</div>
+            <img data-src="https://static.${merchantId}.test/iphone.jpg" />
+          </div>
+        </div>
+      `;
+    case 'bim':
+      return `
+        <ul class="product-list">
+          <li class="product-item" data-sku="${merchantId}-iphone" data-url="/${merchantId}/iphone-15-pro">
+            <a class="product-item__title" href="/${merchantId}/iphone-15-pro">Apple iPhone 15 Pro</a>
+            <div class="product-item__brand">Apple</div>
+            <div class="product-item__category">Smartphones</div>
+            <div class="product-item__price">${price} DH</div>
+            <div class="product-item__shipping">${shippingText}</div>
+            <div class="product-item__availability">Disponible</div>
+            <img data-src="https://static.${merchantId}.test/iphone.jpg" />
+          </li>
+        </ul>
+      `;
+    case 'decathlon':
+      return `
+        <section class="plp-product-list">
+          <article class="plp-product" data-product-sku="${merchantId}-iphone" data-url="/${merchantId}/iphone-15-pro">
+            <a class="plp-product__main-link" href="/${merchantId}/iphone-15-pro">
+              <span class="plp-product__title">Apple iPhone 15 Pro</span>
+            </a>
+            <span class="plp-product__brand">Apple</span>
+            <span class="plp-product__sport">Smartphones</span>
+            <span class="plp-product-price__current">${price} DH</span>
+            <span class="plp-product__delivery">${shippingText}</span>
+            <span class="plp-product__availability">En stock</span>
+            <img data-src="https://static.${merchantId}.test/iphone.jpg" />
+          </article>
+        </section>
+      `;
+    case 'hm':
+      return `
+        <ul class="products-listing">
+          <li class="product-item" data-articlecode="${merchantId}-iphone" data-url="/${merchantId}/iphone-15-pro">
+            <a class="item-link" href="/${merchantId}/iphone-15-pro">
+              <h3 class="item-heading">Chemise en Lin Homme</h3>
+            </a>
+            <div class="item-brand">H&M</div>
+            <div class="item-category">Mode</div>
+            <div class="item-price">${price} MAD</div>
+            <div class="item-delivery">${shippingText}</div>
+            <div class="item-availability">En stock</div>
+            <img data-src="https://static.${merchantId}.test/chemise.jpg" />
+          </li>
+        </ul>
+      `;
+    default:
+      return '';
+  }
+};
 
 for (const merchant of merchantMocks) {
   process.env[merchant.env] = merchant.url;

--- a/backend/src/integrations/bim.ts
+++ b/backend/src/integrations/bim.ts
@@ -1,9 +1,155 @@
-import { createProductCardIntegration } from './utils';
+import { parseDocument, DomUtils } from 'htmlparser2';
+import { Element, isTag } from 'domhandler';
+import { merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+import {
+  buildSearchUrl,
+  delay,
+  fetchWithConfig,
+  getMerchantHttpConfig,
+  parseAvailability,
+  parsePrice,
+  parseShippingFee,
+  resolveUrl,
+  slugify,
+} from './utils';
 
-export const bimIntegration = createProductCardIntegration({
-  merchantId: 'bim',
+const profile = merchantProfiles.bim;
+
+interface ParseOptions {
+  origin: string;
+  currency: string;
+}
+
+const hasClass = (element: Element | null | undefined, className: string) => {
+  if (!element) {
+    return false;
+  }
+  const classAttr = DomUtils.getAttributeValue(element, 'class');
+  if (!classAttr) {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((value) => value === className);
+};
+
+const findFirst = (root: Element, predicate: (element: Element) => boolean) =>
+  DomUtils.findOne((node): node is Element => isTag(node) && predicate(node), root.children, true);
+
+const getText = (element: Element | null | undefined) =>
+  element ? DomUtils.textContent(element).trim() : '';
+
+const parseBimOffers = (html: string, options: ParseOptions): MerchantOffer[] => {
+  const document = parseDocument(html);
+  const offers: MerchantOffer[] = [];
+
+  const products = DomUtils.findAll(
+    (node): node is Element => isTag(node) && hasClass(node, 'product-item'),
+    document.children
+  );
+
+  for (const product of products) {
+    const productId =
+      DomUtils.getAttributeValue(product, 'data-sku') ??
+      DomUtils.getAttributeValue(product, 'data-id') ??
+      DomUtils.getAttributeValue(product, 'data-product-id');
+
+    const link = findFirst(product, (element) => hasClass(element, 'product-item__title') || hasClass(element, 'product-link'));
+    const titleNode = link ?? findFirst(product, (element) => hasClass(element, 'product-title'));
+    const title = getText(titleNode);
+    const priceNode =
+      findFirst(product, (element) => hasClass(element, 'product-item__price')) ??
+      findFirst(product, (element) => hasClass(element, 'price'));
+    const priceText = priceNode ? getText(priceNode) : '';
+    const price = parsePrice(priceText);
+
+    if (!productId || !title || typeof price !== 'number') {
+      continue;
+    }
+
+    const brand = getText(findFirst(product, (element) => hasClass(element, 'product-item__brand') || hasClass(element, 'product-brand')));
+    const category = getText(
+      findFirst(product, (element) => hasClass(element, 'product-item__category') || hasClass(element, 'product-category'))
+    );
+
+    const imageNode = findFirst(product, (element) => element.name === 'img');
+    const imageSrc =
+      (imageNode && (DomUtils.getAttributeValue(imageNode, 'data-src') ?? DomUtils.getAttributeValue(imageNode, 'src')))
+        || undefined;
+
+    const shippingNode = findFirst(product, (element) => hasClass(element, 'product-item__shipping') || hasClass(element, 'shipping'));
+    const shippingText = shippingNode ? getText(shippingNode) : undefined;
+    const shippingFee = parseShippingFee(shippingText);
+
+    const availabilityNode = findFirst(
+      product,
+      (element) => hasClass(element, 'product-item__availability') || hasClass(element, 'availability')
+    );
+    const availabilityText = availabilityNode ? getText(availabilityNode) : undefined;
+    const currencyAttr = DomUtils.getAttributeValue(product, 'data-currency');
+
+    const href = (link && DomUtils.getAttributeValue(link, 'href')) ?? DomUtils.getAttributeValue(product, 'data-url') ?? '';
+    const slugSource =
+      DomUtils.getAttributeValue(product, 'data-slug') ??
+      DomUtils.getAttributeValue(product, 'data-sku') ??
+      href ??
+      title;
+    const slug = slugify(slugSource || title) || slugify(title);
+
+    offers.push({
+      offerId: `${profile.id}-${productId}`,
+      merchant: profile,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image: imageSrc ? resolveUrl(imageSrc, options.origin, profile.url) : undefined,
+      price,
+      currency: (currencyAttr ?? options.currency).toUpperCase(),
+      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+      availability: parseAvailability(availabilityText),
+      url: resolveUrl(href, options.origin, profile.url),
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const bimIntegration: MerchantIntegration = {
+  id: profile.id,
   label: 'BIM',
-  defaultSearchUrl: 'https://www.bim.ma/recherche',
-  defaultQueryParam: 'query',
-  defaultCurrency: 'MAD',
-});
+  profile,
+  async search(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const config = getMerchantHttpConfig('bim', {
+      searchUrl: 'https://www.bim.ma/recherche',
+      queryParam: 'query',
+      currency: 'MAD',
+    });
+
+    if (config.delayMs) {
+      await delay(config.delayMs);
+    }
+
+    const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
+    const response = await fetchWithConfig(url, {
+      headers: config.headers,
+      timeoutMs: config.timeoutMs,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    }
+
+    const html = await response.text();
+    return parseBimOffers(html, { origin: config.origin, currency: config.currency });
+  },
+};

--- a/backend/src/integrations/decathlon.ts
+++ b/backend/src/integrations/decathlon.ts
@@ -1,9 +1,161 @@
-import { createProductCardIntegration } from './utils';
+import { parseDocument, DomUtils } from 'htmlparser2';
+import { Element, isTag } from 'domhandler';
+import { merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+import {
+  buildSearchUrl,
+  delay,
+  fetchWithConfig,
+  getMerchantHttpConfig,
+  parseAvailability,
+  parsePrice,
+  parseShippingFee,
+  resolveUrl,
+  slugify,
+} from './utils';
 
-export const decathlonIntegration = createProductCardIntegration({
-  merchantId: 'decathlon',
+const profile = merchantProfiles.decathlon;
+
+interface ParseOptions {
+  origin: string;
+  currency: string;
+}
+
+const hasClass = (element: Element | null | undefined, className: string) => {
+  if (!element) {
+    return false;
+  }
+  const classAttr = DomUtils.getAttributeValue(element, 'class');
+  if (!classAttr) {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((value) => value === className);
+};
+
+const findFirst = (root: Element, predicate: (element: Element) => boolean) =>
+  DomUtils.findOne((node): node is Element => isTag(node) && predicate(node), root.children, true);
+
+const getText = (element: Element | null | undefined) =>
+  element ? DomUtils.textContent(element).trim() : '';
+
+const parseDecathlonOffers = (html: string, options: ParseOptions): MerchantOffer[] => {
+  const document = parseDocument(html);
+  const offers: MerchantOffer[] = [];
+
+  const products = DomUtils.findAll(
+    (node): node is Element =>
+      isTag(node) && (hasClass(node, 'plp-product') || hasClass(node, 'product-card') || hasClass(node, 'plp-product-card')),
+    document.children
+  );
+
+  for (const product of products) {
+    const productId =
+      DomUtils.getAttributeValue(product, 'data-product-sku') ??
+      DomUtils.getAttributeValue(product, 'data-product-id') ??
+      DomUtils.getAttributeValue(product, 'data-sku');
+
+    const link = findFirst(product, (element) => hasClass(element, 'plp-product__main-link') || hasClass(element, 'product-card__link'))
+      ?? findFirst(product, (element) => element.name === 'a');
+    const titleNode =
+      (link && findFirst(link, (element) => hasClass(element, 'plp-product__title') || hasClass(element, 'product-card__title')))
+        ?? findFirst(product, (element) => hasClass(element, 'plp-product__title') || hasClass(element, 'product-card__title'))
+        ?? findFirst(product, (element) => element.name === 'h2' || element.name === 'h3');
+    const title = getText(titleNode);
+    const priceNode =
+      findFirst(product, (element) => hasClass(element, 'plp-product-price__current')) ??
+      findFirst(product, (element) => hasClass(element, 'product-card__price')) ??
+      findFirst(product, (element) => hasClass(element, 'price'));
+    const priceText = priceNode ? getText(priceNode) : '';
+    const price = parsePrice(priceText);
+
+    if (!productId || !title || typeof price !== 'number') {
+      continue;
+    }
+
+    const brand = getText(findFirst(product, (element) => hasClass(element, 'plp-product__brand') || hasClass(element, 'product-card__brand')));
+    const category = getText(
+      findFirst(product, (element) => hasClass(element, 'plp-product__sport') || hasClass(element, 'product-card__category'))
+    );
+
+    const imageNode = findFirst(product, (element) => element.name === 'img');
+    const imageSrc =
+      (imageNode &&
+        (DomUtils.getAttributeValue(imageNode, 'data-src') ??
+          DomUtils.getAttributeValue(imageNode, 'data-srcset') ??
+          DomUtils.getAttributeValue(imageNode, 'src')))
+        || undefined;
+
+    const shippingNode = findFirst(product, (element) => hasClass(element, 'plp-product__delivery') || hasClass(element, 'delivery'));
+    const shippingText = shippingNode ? getText(shippingNode) : undefined;
+    const shippingFee = parseShippingFee(shippingText);
+
+    const availabilityNode = findFirst(product, (element) => hasClass(element, 'plp-product__availability') || hasClass(element, 'availability'));
+    const availabilityText = availabilityNode ? getText(availabilityNode) : undefined;
+    const currencyAttr = DomUtils.getAttributeValue(product, 'data-currency');
+
+    const href = (link && DomUtils.getAttributeValue(link, 'href')) ?? DomUtils.getAttributeValue(product, 'data-url') ?? '';
+    const slugSource =
+      DomUtils.getAttributeValue(product, 'data-product-sku') ??
+      DomUtils.getAttributeValue(product, 'data-url-key') ??
+      href ??
+      title;
+    const slug = slugify(slugSource || title) || slugify(title);
+
+    offers.push({
+      offerId: `${profile.id}-${productId}`,
+      merchant: profile,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image: imageSrc ? resolveUrl(imageSrc, options.origin, profile.url) : undefined,
+      price,
+      currency: (currencyAttr ?? options.currency).toUpperCase(),
+      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+      availability: parseAvailability(availabilityText),
+      url: resolveUrl(href, options.origin, profile.url),
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const decathlonIntegration: MerchantIntegration = {
+  id: profile.id,
   label: 'Decathlon',
-  defaultSearchUrl: 'https://www.decathlon.ma/search',
-  defaultQueryParam: 'q',
-  defaultCurrency: 'MAD',
-});
+  profile,
+  async search(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const config = getMerchantHttpConfig('decathlon', {
+      searchUrl: 'https://www.decathlon.ma/search',
+      queryParam: 'q',
+      currency: 'MAD',
+    });
+
+    if (config.delayMs) {
+      await delay(config.delayMs);
+    }
+
+    const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
+    const response = await fetchWithConfig(url, {
+      headers: config.headers,
+      timeoutMs: config.timeoutMs,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    }
+
+    const html = await response.text();
+    return parseDecathlonOffers(html, { origin: config.origin, currency: config.currency });
+  },
+};

--- a/backend/src/integrations/electroplanet.ts
+++ b/backend/src/integrations/electroplanet.ts
@@ -1,9 +1,153 @@
-import { createProductCardIntegration } from './utils';
+import { parseDocument, DomUtils } from 'htmlparser2';
+import { Element, isTag } from 'domhandler';
+import { merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+import {
+  buildSearchUrl,
+  delay,
+  fetchWithConfig,
+  getMerchantHttpConfig,
+  parseAvailability,
+  parsePrice,
+  parseShippingFee,
+  resolveUrl,
+  slugify,
+} from './utils';
 
-export const electroplanetIntegration = createProductCardIntegration({
-  merchantId: 'electroplanet',
+const profile = merchantProfiles.electroplanet;
+
+interface ParseOptions {
+  origin: string;
+  currency: string;
+}
+
+const hasClass = (element: Element | null | undefined, className: string) => {
+  if (!element) {
+    return false;
+  }
+  const classAttr = DomUtils.getAttributeValue(element, 'class');
+  if (!classAttr) {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((value) => value === className);
+};
+
+const findFirst = (root: Element, predicate: (element: Element) => boolean) =>
+  DomUtils.findOne((node): node is Element => isTag(node) && predicate(node), root.children, true);
+
+const getText = (element: Element | null | undefined) =>
+  element ? DomUtils.textContent(element).trim() : '';
+
+const parseElectroplanetOffers = (html: string, options: ParseOptions): MerchantOffer[] => {
+  const document = parseDocument(html);
+  const offers: MerchantOffer[] = [];
+
+  const products = DomUtils.findAll(
+    (node): node is Element =>
+      isTag(node) &&
+      (hasClass(node, 'product-item') || hasClass(node, 'product-item-info') || node.name === 'li'),
+    document.children
+  ).filter((element) => hasClass(element, 'product-item'));
+
+  for (const product of products) {
+    const info = findFirst(product, (element) => hasClass(element, 'product-item-info')) ?? product;
+
+    const productId =
+      DomUtils.getAttributeValue(product, 'data-product-id') ??
+      DomUtils.getAttributeValue(product, 'data-sku') ??
+      DomUtils.getAttributeValue(info, 'data-product-id');
+
+    const link = findFirst(info, (element) => hasClass(element, 'product-item-link')) ?? undefined;
+    const titleNode = link ?? findFirst(info, (element) => hasClass(element, 'product') && hasClass(element, 'name'));
+    const title = getText(titleNode);
+    const priceNode = findFirst(info, (element) => hasClass(element, 'price-box'));
+    const priceValueNode = priceNode ? findFirst(priceNode, (element) => hasClass(element, 'price')) : undefined;
+    const priceText = getText(priceValueNode);
+    const price = parsePrice(priceText);
+
+    if (!productId || !title || typeof price !== 'number') {
+      continue;
+    }
+
+    const brand = getText(findFirst(info, (element) => hasClass(element, 'product-brand')));
+    const category = getText(findFirst(info, (element) => hasClass(element, 'product-category')));
+
+    const imageNode = findFirst(info, (element) => element.name === 'img');
+    const imageSrc =
+      (imageNode && (DomUtils.getAttributeValue(imageNode, 'data-src') ?? DomUtils.getAttributeValue(imageNode, 'src')))
+        || undefined;
+
+    const shippingNode = findFirst(info, (element) => hasClass(element, 'shipping') || hasClass(element, 'delivery'));
+    const shippingText = shippingNode ? getText(shippingNode) : undefined;
+    const shippingFee = parseShippingFee(shippingText);
+
+    const availabilityNode = findFirst(info, (element) => hasClass(element, 'stock') || hasClass(element, 'availability'));
+    const availabilityText = availabilityNode ? getText(availabilityNode) : undefined;
+    const currencyAttr = DomUtils.getAttributeValue(priceValueNode ?? priceNode ?? product, 'data-price-currency');
+
+    const href = (link && DomUtils.getAttributeValue(link, 'href')) ?? DomUtils.getAttributeValue(product, 'data-product-url');
+    const slugSource =
+      DomUtils.getAttributeValue(product, 'data-url-key') ??
+      DomUtils.getAttributeValue(product, 'data-sku') ??
+      href ??
+      title;
+    const slug = slugify(slugSource || title) || slugify(title);
+
+    offers.push({
+      offerId: `${profile.id}-${productId}`,
+      merchant: profile,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image: imageSrc ? resolveUrl(imageSrc, options.origin, profile.url) : undefined,
+      price,
+      currency: (currencyAttr ?? options.currency).toUpperCase(),
+      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+      availability: parseAvailability(availabilityText),
+      url: resolveUrl(href, options.origin, profile.url),
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const electroplanetIntegration: MerchantIntegration = {
+  id: profile.id,
   label: 'Electroplanet',
-  defaultSearchUrl: 'https://www.electroplanet.ma/catalogsearch/result/',
-  defaultQueryParam: 'q',
-  defaultCurrency: 'MAD',
-});
+  profile,
+  async search(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const config = getMerchantHttpConfig('electroplanet', {
+      searchUrl: 'https://www.electroplanet.ma/catalogsearch/result/',
+      queryParam: 'q',
+      currency: 'MAD',
+    });
+
+    if (config.delayMs) {
+      await delay(config.delayMs);
+    }
+
+    const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
+    const response = await fetchWithConfig(url, {
+      headers: config.headers,
+      timeoutMs: config.timeoutMs,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    }
+
+    const html = await response.text();
+    return parseElectroplanetOffers(html, { origin: config.origin, currency: config.currency });
+  },
+};

--- a/backend/src/integrations/hm.ts
+++ b/backend/src/integrations/hm.ts
@@ -1,9 +1,160 @@
-import { createProductCardIntegration } from './utils';
+import { parseDocument, DomUtils } from 'htmlparser2';
+import { Element, isTag } from 'domhandler';
+import { merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+import {
+  buildSearchUrl,
+  delay,
+  fetchWithConfig,
+  getMerchantHttpConfig,
+  parseAvailability,
+  parsePrice,
+  parseShippingFee,
+  resolveUrl,
+  slugify,
+} from './utils';
 
-export const hmIntegration = createProductCardIntegration({
-  merchantId: 'hm',
+const profile = merchantProfiles.hm;
+
+interface ParseOptions {
+  origin: string;
+  currency: string;
+}
+
+const hasClass = (element: Element | null | undefined, className: string) => {
+  if (!element) {
+    return false;
+  }
+  const classAttr = DomUtils.getAttributeValue(element, 'class');
+  if (!classAttr) {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((value) => value === className);
+};
+
+const findFirst = (root: Element, predicate: (element: Element) => boolean) =>
+  DomUtils.findOne((node): node is Element => isTag(node) && predicate(node), root.children, true);
+
+const getText = (element: Element | null | undefined) =>
+  element ? DomUtils.textContent(element).trim() : '';
+
+const parseHmOffers = (html: string, options: ParseOptions): MerchantOffer[] => {
+  const document = parseDocument(html);
+  const offers: MerchantOffer[] = [];
+
+  const products = DomUtils.findAll(
+    (node): node is Element =>
+      isTag(node) && (hasClass(node, 'product-item') || hasClass(node, 'product')),
+    document.children
+  );
+
+  for (const product of products) {
+    const productId =
+      DomUtils.getAttributeValue(product, 'data-articlecode') ??
+      DomUtils.getAttributeValue(product, 'data-product-id') ??
+      DomUtils.getAttributeValue(product, 'data-sku');
+
+    const link = findFirst(product, (element) => hasClass(element, 'item-link') || hasClass(element, 'product-item__link'))
+      ?? findFirst(product, (element) => element.name === 'a');
+    const titleNode =
+      (link && findFirst(link, (element) => hasClass(element, 'item-heading') || hasClass(element, 'product-item-heading')))
+        ?? findFirst(product, (element) => hasClass(element, 'item-heading') || hasClass(element, 'product-item-heading'))
+        ?? findFirst(product, (element) => element.name === 'h3');
+    const title = getText(titleNode);
+    const priceNode =
+      findFirst(product, (element) => hasClass(element, 'item-price')) ??
+      findFirst(product, (element) => hasClass(element, 'product-item-price')) ??
+      findFirst(product, (element) => hasClass(element, 'price'));
+    const priceText = priceNode ? getText(priceNode) : '';
+    const price = parsePrice(priceText);
+
+    if (!productId || !title || typeof price !== 'number') {
+      continue;
+    }
+
+    const brand = getText(findFirst(product, (element) => hasClass(element, 'item-brand') || hasClass(element, 'product-item-brand')));
+    const category = getText(
+      findFirst(product, (element) => hasClass(element, 'item-category') || hasClass(element, 'product-item-category'))
+    );
+
+    const imageNode = findFirst(product, (element) => element.name === 'img');
+    const imageSrc =
+      (imageNode &&
+        (DomUtils.getAttributeValue(imageNode, 'data-src') ??
+          DomUtils.getAttributeValue(imageNode, 'data-altimage') ??
+          DomUtils.getAttributeValue(imageNode, 'src')))
+        || undefined;
+
+    const shippingNode = findFirst(product, (element) => hasClass(element, 'item-delivery') || hasClass(element, 'delivery'));
+    const shippingText = shippingNode ? getText(shippingNode) : undefined;
+    const shippingFee = parseShippingFee(shippingText);
+
+    const availabilityNode = findFirst(product, (element) => hasClass(element, 'item-availability') || hasClass(element, 'availability'));
+    const availabilityText = availabilityNode ? getText(availabilityNode) : undefined;
+    const currencyAttr = DomUtils.getAttributeValue(product, 'data-currency');
+
+    const href = (link && DomUtils.getAttributeValue(link, 'href')) ?? DomUtils.getAttributeValue(product, 'data-url') ?? '';
+    const slugSource =
+      DomUtils.getAttributeValue(product, 'data-articlecode') ??
+      href ??
+      title;
+    const slug = slugify(slugSource || title) || slugify(title);
+
+    offers.push({
+      offerId: `${profile.id}-${productId}`,
+      merchant: profile,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image: imageSrc ? resolveUrl(imageSrc, options.origin, profile.url) : undefined,
+      price,
+      currency: (currencyAttr ?? options.currency).toUpperCase(),
+      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+      availability: parseAvailability(availabilityText),
+      url: resolveUrl(href, options.origin, profile.url),
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const hmIntegration: MerchantIntegration = {
+  id: profile.id,
   label: 'H&M',
-  defaultSearchUrl: 'https://www2.hm.com/fr_ma/search-results.html',
-  defaultQueryParam: 'q',
-  defaultCurrency: 'MAD',
-});
+  profile,
+  async search(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const config = getMerchantHttpConfig('hm', {
+      searchUrl: 'https://www2.hm.com/fr_ma/search-results.html',
+      queryParam: 'q',
+      currency: 'MAD',
+    });
+
+    if (config.delayMs) {
+      await delay(config.delayMs);
+    }
+
+    const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
+    const response = await fetchWithConfig(url, {
+      headers: config.headers,
+      timeoutMs: config.timeoutMs,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    }
+
+    const html = await response.text();
+    return parseHmOffers(html, { origin: config.origin, currency: config.currency });
+  },
+};

--- a/backend/src/integrations/jumia.ts
+++ b/backend/src/integrations/jumia.ts
@@ -1,9 +1,152 @@
-import { createProductCardIntegration } from './utils';
+import { parseDocument, DomUtils } from 'htmlparser2';
+import { Element, isTag } from 'domhandler';
+import { merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+import {
+  buildSearchUrl,
+  delay,
+  fetchWithConfig,
+  getMerchantHttpConfig,
+  parseAvailability,
+  parsePrice,
+  parseShippingFee,
+  resolveUrl,
+  slugify,
+} from './utils';
 
-export const jumiaIntegration = createProductCardIntegration({
-  merchantId: 'jumia',
+const profile = merchantProfiles.jumia;
+
+interface ParseOptions {
+  origin: string;
+  currency: string;
+}
+
+const hasClass = (element: Element | null | undefined, className: string) => {
+  if (!element) {
+    return false;
+  }
+  const classAttr = DomUtils.getAttributeValue(element, 'class');
+  if (!classAttr) {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((value) => value === className);
+};
+
+const findFirst = (root: Element, predicate: (element: Element) => boolean) =>
+  DomUtils.findOne((node): node is Element => isTag(node) && predicate(node), root.children, true);
+
+const getText = (element: Element | null | undefined) =>
+  element ? DomUtils.textContent(element).trim() : '';
+
+const parseJumiaOffers = (html: string, options: ParseOptions): MerchantOffer[] => {
+  const document = parseDocument(html);
+  const offers: MerchantOffer[] = [];
+
+  const products = DomUtils.findAll(
+    (node): node is Element =>
+      isTag(node) && (hasClass(node, 'prd') || hasClass(node, 'c-prd')),
+    document.children
+  );
+
+  for (const product of products) {
+    const productId =
+      DomUtils.getAttributeValue(product, 'data-sku') ?? DomUtils.getAttributeValue(product, 'data-id');
+    const link = findFirst(product, (element) => hasClass(element, 'core') || hasClass(element, 'link'));
+    const titleNode = link ?? findFirst(product, (element) => hasClass(element, 'name') || hasClass(element, 'title'));
+    const title = getText(titleNode);
+    const priceNode = findFirst(product, (element) => hasClass(element, 'prc') || hasClass(element, 'price'));
+    const priceText = getText(priceNode);
+    const price = parsePrice(priceText);
+
+    if (!productId || !title || typeof price !== 'number') {
+      continue;
+    }
+
+    const brandAttr = DomUtils.getAttributeValue(product, 'data-brand');
+    const brand = brandAttr ?? getText(findFirst(product, (element) => hasClass(element, 'brand')));
+    const categoryAttr = DomUtils.getAttributeValue(product, 'data-category');
+    const category = categoryAttr ?? getText(findFirst(product, (element) => hasClass(element, 'cat')));
+
+    const imageNode = findFirst(product, (element) => element.name === 'img');
+    const imageSrc =
+      (imageNode &&
+        (DomUtils.getAttributeValue(imageNode, 'data-src') ??
+          DomUtils.getAttributeValue(imageNode, 'data-srcset') ??
+          DomUtils.getAttributeValue(imageNode, 'src')))
+        || undefined;
+
+    const shippingNode = findFirst(product, (element) => hasClass(element, 'shp') || hasClass(element, 'delivery'));
+    const shippingText = shippingNode ? getText(shippingNode) : undefined;
+    const shippingFee = parseShippingFee(shippingText);
+
+    const availabilityNode = findFirst(product, (element) => hasClass(element, 'stk') || hasClass(element, 'availability'));
+    const availabilityText = availabilityNode ? getText(availabilityNode) : undefined;
+    const currencyAttr = DomUtils.getAttributeValue(product, 'data-currency');
+
+    const href =
+      (link && DomUtils.getAttributeValue(link, 'href')) ?? DomUtils.getAttributeValue(product, 'data-url') ?? '';
+    const slugSource =
+      DomUtils.getAttributeValue(product, 'data-name') ??
+      DomUtils.getAttributeValue(product, 'data-sku') ??
+      href ??
+      title;
+    const slug = slugify(slugSource || title) || slugify(title);
+
+    offers.push({
+      offerId: `${profile.id}-${productId}`,
+      merchant: profile,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image: imageSrc ? resolveUrl(imageSrc, options.origin, profile.url) : undefined,
+      price,
+      currency: (currencyAttr ?? options.currency).toUpperCase(),
+      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+      availability: parseAvailability(availabilityText),
+      url: resolveUrl(href, options.origin, profile.url),
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const jumiaIntegration: MerchantIntegration = {
+  id: profile.id,
   label: 'Jumia',
-  defaultSearchUrl: 'https://www.jumia.ma/catalog/',
-  defaultQueryParam: 'q',
-  defaultCurrency: 'MAD',
-});
+  profile,
+  async search(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const config = getMerchantHttpConfig('jumia', {
+      searchUrl: 'https://www.jumia.ma/catalog/',
+      queryParam: 'q',
+      currency: 'MAD',
+    });
+
+    if (config.delayMs) {
+      await delay(config.delayMs);
+    }
+
+    const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
+    const response = await fetchWithConfig(url, {
+      headers: config.headers,
+      timeoutMs: config.timeoutMs,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    }
+
+    const html = await response.text();
+    return parseJumiaOffers(html, { origin: config.origin, currency: config.currency });
+  },
+};

--- a/backend/src/integrations/marjane.ts
+++ b/backend/src/integrations/marjane.ts
@@ -1,9 +1,158 @@
-import { createProductCardIntegration } from './utils';
+import { parseDocument, DomUtils } from 'htmlparser2';
+import { Element, isTag } from 'domhandler';
+import { merchantProfiles } from './fixtures/merchantData';
+import { MerchantIntegration, MerchantOffer } from './types';
+import {
+  buildSearchUrl,
+  delay,
+  fetchWithConfig,
+  getMerchantHttpConfig,
+  parseAvailability,
+  parsePrice,
+  parseShippingFee,
+  resolveUrl,
+  slugify,
+} from './utils';
 
-export const marjaneIntegration = createProductCardIntegration({
-  merchantId: 'marjane',
+const profile = merchantProfiles.marjane;
+
+interface ParseOptions {
+  origin: string;
+  currency: string;
+}
+
+const hasClass = (element: Element | null | undefined, className: string) => {
+  if (!element) {
+    return false;
+  }
+  const classAttr = DomUtils.getAttributeValue(element, 'class');
+  if (!classAttr) {
+    return false;
+  }
+  return classAttr
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((value) => value === className);
+};
+
+const findFirst = (root: Element, predicate: (element: Element) => boolean) =>
+  DomUtils.findOne((node): node is Element => isTag(node) && predicate(node), root.children, true);
+
+const getText = (element: Element | null | undefined) =>
+  element ? DomUtils.textContent(element).trim() : '';
+
+const parseMarjaneOffers = (html: string, options: ParseOptions): MerchantOffer[] => {
+  const document = parseDocument(html);
+  const offers: MerchantOffer[] = [];
+
+  const products = DomUtils.findAll(
+    (node): node is Element =>
+      isTag(node) &&
+      (hasClass(node, 'product-item') || hasClass(node, 'product-card') || hasClass(node, 'product')),
+    document.children
+  );
+
+  for (const product of products) {
+    const productId =
+      DomUtils.getAttributeValue(product, 'data-product-id') ??
+      DomUtils.getAttributeValue(product, 'data-sku');
+
+    const link = findFirst(product, (element) => hasClass(element, 'product-link') || hasClass(element, 'product-card-link'));
+    const titleNode =
+      (link && findFirst(link, (element) => hasClass(element, 'product-title'))) ??
+      findFirst(product, (element) => hasClass(element, 'product-title') || element.name === 'h2' || element.name === 'h3');
+    const title = getText(titleNode);
+    const priceNode =
+      findFirst(product, (element) => hasClass(element, 'price-amount')) ??
+      findFirst(product, (element) => hasClass(element, 'product-price')) ??
+      findFirst(product, (element) => hasClass(element, 'price'));
+    const priceText = priceNode ? getText(priceNode) : '';
+    const price = parsePrice(priceText);
+
+    if (!productId || !title || typeof price !== 'number') {
+      continue;
+    }
+
+    const brand = getText(findFirst(product, (element) => hasClass(element, 'product-brand') || hasClass(element, 'brand')));
+    const category = getText(findFirst(product, (element) => hasClass(element, 'product-category') || hasClass(element, 'category')));
+
+    const imageNode = findFirst(product, (element) => element.name === 'img');
+    const imageSrc =
+      (imageNode &&
+        (DomUtils.getAttributeValue(imageNode, 'data-src') ??
+          DomUtils.getAttributeValue(imageNode, 'data-lazy-src') ??
+          DomUtils.getAttributeValue(imageNode, 'src')))
+        || undefined;
+
+    const shippingNode = findFirst(product, (element) => hasClass(element, 'product-shipping') || hasClass(element, 'shipping'));
+    const shippingText = shippingNode ? getText(shippingNode) : undefined;
+    const shippingFee = parseShippingFee(shippingText);
+
+    const availabilityNode = findFirst(product, (element) => hasClass(element, 'product-stock') || hasClass(element, 'availability'));
+    const availabilityText = availabilityNode ? getText(availabilityNode) : undefined;
+    const currencyAttr = DomUtils.getAttributeValue(product, 'data-currency');
+
+    const href =
+      (link && DomUtils.getAttributeValue(link, 'href')) ?? DomUtils.getAttributeValue(product, 'data-url') ?? '';
+    const slugSource =
+      DomUtils.getAttributeValue(product, 'data-slug') ??
+      DomUtils.getAttributeValue(product, 'data-sku') ??
+      href ??
+      title;
+    const slug = slugify(slugSource || title) || slugify(title);
+
+    offers.push({
+      offerId: `${profile.id}-${productId}`,
+      merchant: profile,
+      productId,
+      slug,
+      title,
+      brand: brand || undefined,
+      category: category || undefined,
+      image: imageSrc ? resolveUrl(imageSrc, options.origin, profile.url) : undefined,
+      price,
+      currency: (currencyAttr ?? options.currency).toUpperCase(),
+      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+      availability: parseAvailability(availabilityText),
+      url: resolveUrl(href, options.origin, profile.url),
+      scrapedAt: new Date().toISOString(),
+    });
+  }
+
+  return offers;
+};
+
+export const marjaneIntegration: MerchantIntegration = {
+  id: profile.id,
   label: 'Marjane',
-  defaultSearchUrl: 'https://www.marjane.ma/search',
-  defaultQueryParam: 'q',
-  defaultCurrency: 'MAD',
-});
+  profile,
+  async search(query: string) {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const config = getMerchantHttpConfig('marjane', {
+      searchUrl: 'https://www.marjane.ma/search',
+      queryParam: 'q',
+      currency: 'MAD',
+    });
+
+    if (config.delayMs) {
+      await delay(config.delayMs);
+    }
+
+    const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
+    const response = await fetchWithConfig(url, {
+      headers: config.headers,
+      timeoutMs: config.timeoutMs,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    }
+
+    const html = await response.text();
+    return parseMarjaneOffers(html, { origin: config.origin, currency: config.currency });
+  },
+};

--- a/backend/src/integrations/utils.ts
+++ b/backend/src/integrations/utils.ts
@@ -1,7 +1,4 @@
-import { parseDocument, DomUtils } from 'htmlparser2';
-import { Element } from 'domhandler';
 import { merchantProfiles } from './fixtures/merchantData';
-import { MerchantIntegration, MerchantOffer, MerchantProfile } from './types';
 
 type MerchantId = keyof typeof merchantProfiles;
 
@@ -167,33 +164,21 @@ export const parsePrice = (input?: string | null) => {
   return Number.isFinite(value) ? value : undefined;
 };
 
-const hasClass = (element: Element, className: string) => {
-  const classAttr = DomUtils.getAttributeValue(element, 'class');
-  if (!classAttr) {
-    return false;
+export const parseShippingFee = (input?: string | null) => {
+  if (!input) {
+    return undefined;
   }
-  return classAttr
-    .split(/\s+/)
-    .filter(Boolean)
-    .some((value) => value === className);
+  const price = parsePrice(input);
+  if (typeof price === 'number') {
+    return price;
+  }
+  if (/gratuit/i.test(input)) {
+    return 0;
+  }
+  return undefined;
 };
 
-const findChild = (root: Element, tagName: string, className?: string) =>
-  DomUtils.findOne(
-    (element) => {
-      if (element.name !== tagName) {
-        return false;
-      }
-      if (!className) {
-        return true;
-      }
-      return hasClass(element, className);
-    },
-    root.children,
-    true
-  );
-
-const resolveUrl = (value: string | undefined, origin: string, fallback: string) => {
+export const resolveUrl = (value: string | undefined, origin: string, fallback: string) => {
   if (!value) {
     return fallback;
   }
@@ -204,12 +189,23 @@ const resolveUrl = (value: string | undefined, origin: string, fallback: string)
   }
 };
 
-const slugify = (value: string) =>
-  normalizeText(value)
+export const slugify = (value: string) => {
+  if (!value) {
+    return '';
+  }
+
+  const cleaned = value
+    .replace(/https?:\/\/[^/]+/gi, ' ')
+    .replace(/[?#].*$/g, ' ')
+    .replace(/\.[a-z0-9]+$/gi, ' ')
+    .replace(/[_/]+/g, ' ');
+
+  return normalizeText(cleaned)
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)+/g, '');
+};
 
-const parseAvailability = (value?: string | null) => {
+export const parseAvailability = (value?: string | null) => {
   if (!value) {
     return 'unknown' as const;
   }
@@ -222,72 +218,6 @@ const parseAvailability = (value?: string | null) => {
   }
   return 'unknown' as const;
 };
-
-export interface ParseProductCardsOptions {
-  profile: MerchantProfile;
-  currency: string;
-  origin: string;
-}
-
-export const parseProductCards = (
-  html: string,
-  options: ParseProductCardsOptions
-): MerchantOffer[] => {
-  const document = parseDocument(html);
-  const cards = DomUtils.findAll(
-    (element) => element.name === 'article' && hasClass(element, 'product-card'),
-    document.children
-  );
-
-  const offers: MerchantOffer[] = [];
-  for (const card of cards) {
-    const productId = DomUtils.getAttributeValue(card, 'data-product-id');
-    const slugAttr = DomUtils.getAttributeValue(card, 'data-product-slug');
-    const titleFromNode = findChild(card, 'h3', 'product-title');
-    const title = titleFromNode ? DomUtils.textContent(titleFromNode).trim() : '';
-    const slug = slugAttr || slugify(title);
-    const priceAttr = DomUtils.getAttributeValue(card, 'data-price');
-    const price = parsePrice(priceAttr);
-
-    if (!productId || !slug || !title || typeof price === 'undefined') {
-      continue;
-    }
-
-    const brandNode = findChild(card, 'span', 'product-brand');
-    const categoryNode = findChild(card, 'span', 'product-category');
-    const shippingAttr = DomUtils.getAttributeValue(card, 'data-shipping-fee');
-    const shippingFee = parsePrice(shippingAttr);
-    const availabilityAttr = DomUtils.getAttributeValue(card, 'data-availability');
-    const availability = parseAvailability(availabilityAttr);
-    const currencyAttr = DomUtils.getAttributeValue(card, 'data-currency');
-
-    const imageNode = findChild(card, 'img');
-    const image = imageNode
-      ? DomUtils.getAttributeValue(imageNode, 'src') || DomUtils.getAttributeValue(imageNode, 'data-src')
-      : undefined;
-    const url = DomUtils.getAttributeValue(card, 'data-product-url');
-
-    offers.push({
-      offerId: `${options.profile.id}-${productId}`,
-      merchant: options.profile,
-      productId,
-      slug,
-      title,
-      brand: brandNode ? DomUtils.textContent(brandNode).trim() || undefined : undefined,
-      category: categoryNode ? DomUtils.textContent(categoryNode).trim() || undefined : undefined,
-      image: image ? resolveUrl(image, options.origin, options.profile.url) : undefined,
-      price,
-      currency: (currencyAttr ?? options.currency).toUpperCase(),
-      shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
-      availability,
-      url: resolveUrl(url, options.origin, options.profile.url),
-      scrapedAt: new Date().toISOString(),
-    });
-  }
-
-  return offers;
-};
-
 export const createRateLimiter = (minimumIntervalMs: number) => {
   const lastInvocations = new Map<string, number>();
   return async (key: string) => {
@@ -302,60 +232,5 @@ export const createRateLimiter = (minimumIntervalMs: number) => {
       await delay(minimumIntervalMs - delta);
     }
     lastInvocations.set(key, Date.now());
-  };
-};
-
-export interface ProductCardIntegrationOptions {
-  merchantId: MerchantId;
-  label: string;
-  defaultSearchUrl: string;
-  defaultQueryParam?: string;
-  defaultCurrency?: string;
-}
-
-export const createProductCardIntegration = (
-  options: ProductCardIntegrationOptions
-): MerchantIntegration => {
-  const profile = merchantProfiles[options.merchantId];
-  const defaultQueryParam = options.defaultQueryParam ?? 'q';
-  const defaultCurrency = options.defaultCurrency ?? 'MAD';
-
-  return {
-    id: profile.id,
-    label: options.label,
-    profile,
-    async search(query: string) {
-      const trimmedQuery = query.trim();
-      if (!trimmedQuery) {
-        return [];
-      }
-
-      const config = getMerchantHttpConfig(options.merchantId, {
-        searchUrl: options.defaultSearchUrl,
-        queryParam: defaultQueryParam,
-        currency: defaultCurrency,
-      });
-
-      if (config.delayMs) {
-        await delay(config.delayMs);
-      }
-
-      const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-      const response = await fetchWithConfig(url, {
-        headers: config.headers,
-        timeoutMs: config.timeoutMs,
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
-      }
-
-      const html = await response.text();
-      return parseProductCards(html, {
-        profile,
-        currency: config.currency,
-        origin: config.origin,
-      });
-    },
   };
 };

--- a/backend/src/services/__tests__/productAggregator.test.ts
+++ b/backend/src/services/__tests__/productAggregator.test.ts
@@ -163,37 +163,35 @@ test('captures integration errors without stopping other connectors', async () =
 
 test('fetches offers from HTTP integrations using mocks', async (t) => {
   const electroplanetHtml = `
-    <section class="catalog">
-      <article class="product-card"
-        data-product-id="iphone-ep"
-        data-product-slug="iphone-15-pro"
-        data-product-url="/iphone-15-pro"
-        data-price="13349"
-        data-currency="MAD"
-        data-shipping-fee="0"
-        data-availability="in_stock">
-        <h3 class="product-title">Apple iPhone 15 Pro</h3>
-        <span class="product-brand">Apple</span>
-        <span class="product-category">Smartphones</span>
-        <img src="/images/iphone-15-pro.jpg" alt="Apple iPhone 15 Pro" />
-      </article>
-    </section>
+    <ul class="products list items">
+      <li class="item product product-item" data-product-id="iphone-ep" data-sku="iphone-15-pro" data-product-url="/iphone-15-pro.html">
+        <div class="product-item-info" data-product-id="iphone-ep">
+          <a class="product-item-link" href="/iphone-15-pro.html">
+            <span class="product name product-item-name">Apple iPhone 15 Pro</span>
+          </a>
+          <div class="product-brand">Apple</div>
+          <div class="product-category">Smartphones</div>
+          <div class="price-box">
+            <span class="price" data-price-currency="MAD">13 349,00 dh</span>
+          </div>
+          <div class="shipping">Livraison gratuite</div>
+          <div class="stock available">En stock</div>
+          <img class="product-image-photo" data-src="https://www.electroplanet.ma/media/catalog/product/iphone.jpg" />
+        </div>
+      </li>
+    </ul>
   `;
 
   const jumiaHtml = `
-    <section class="catalog">
-      <article class="product-card"
-        data-product-id="iphone-jumia"
-        data-product-slug="iphone-15-pro"
-        data-product-url="https://www.jumia.ma/iphone-15-pro"
-        data-price="13599"
-        data-currency="MAD"
-        data-shipping-fee="49"
-        data-availability="in_stock">
-        <h3 class="product-title">Apple iPhone 15 Pro 256GB</h3>
-        <span class="product-brand">Apple</span>
-        <span class="product-category">Smartphones</span>
-        <img src="https://www.jumia.ma/images/iphone-15-pro.jpg" alt="Apple iPhone 15 Pro" />
+    <section class="products">
+      <article class="prd _fb col c-prd" data-sku="iphone-jumia" data-url="https://www.jumia.ma/iphone-15-pro" data-brand="Apple" data-category="Smartphones">
+        <a class="core" href="/iphone-15-pro">
+          <div class="name">Apple iPhone 15 Pro 256GB</div>
+        </a>
+        <div class="prc">13 599 DH</div>
+        <div class="shp">Livraison 49 DH</div>
+        <div class="stk _available">En stock</div>
+        <img data-src="https://www.jumia.ma/images/iphone-15-pro.jpg" />
       </article>
     </section>
   `;


### PR DESCRIPTION
## Summary
- replace the generic product-card integration with htmlparser2-based scrapers in each merchant module while reusing shared helpers
- extend the integration utilities with slug, availability, and shipping helpers to support the bespoke parsers
- refresh the product aggregator and server tests with representative HTML snippets from each merchant to validate parsing

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dbcdb84668832597a7076bb263e3be