### PR TITLE
Ensure HTTP defaults respect merchant overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@
    npm run dev
    ```
 
+### Personnaliser les en-têtes HTTP pour le scraping
+
+Les connecteurs HTTP ajoutent automatiquement des en-têtes de base tels que `User-Agent`, `Accept` et `Accept-Language` afin de réduire les blocages côté marchand. Vous pouvez les surcharger (ou les vider) par marchand via les variables d'environnement `*_HEADERS` :
+
+```bash
+ELECTROPLANET_HEADERS='{"user-agent":"AtlasBot/1.0","accept-language":"en-GB,en;q=0.5"}'
+JUMIA_HEADERS='{"accept-language":""}' # désactive la valeur par défaut
+```
+
+Les clés sont fusionnées de manière insensible à la casse : toute valeur fournie remplace la valeur par défaut, tandis que les champs non définis continuent d'utiliser les en-têtes standards.
+
 ## 🗃️ Base de données & Prisma
 
 Une stack PostgreSQL + Prisma est désormais utilisée pour persister les produits, marchands et offres. Après avoir démarré PostgreSQL (via `docker-compose` ou votre instance locale), exécutez les commandes suivantes dans le dossier `backend` :

--- a/backend/src/integrations/utils.ts
+++ b/backend/src/integrations/utils.ts
@@ -147,6 +147,30 @@ const createDefaultHeaders = (targetUrl: string) => {
   return headers;
 };
 
+const mergeHeadersWithDefaults = (
+  defaults: Record<string, string>,
+  overrides: Record<string, string>
+) => {
+  const merged: Record<string, string> = {};
+  const overridesByLowerCase = new Map<string, string>();
+
+  for (const key of Object.keys(overrides)) {
+    overridesByLowerCase.set(key.toLowerCase(), key);
+  }
+
+  for (const [key, value] of Object.entries(defaults)) {
+    if (!overridesByLowerCase.has(key.toLowerCase())) {
+      merged[key] = value;
+    }
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    merged[key] = value;
+  }
+
+  return merged;
+};
+
 export const fetchWithConfig = async (
   url: string,
   options: { headers?: Record<string, string>; timeoutMs?: number } = {}
@@ -157,10 +181,10 @@ export const fetchWithConfig = async (
     : undefined;
 
   try {
-    const mergedHeaders = {
-      ...createDefaultHeaders(url),
-      ...(options.headers ?? {}),
-    };
+    const mergedHeaders = mergeHeadersWithDefaults(
+      createDefaultHeaders(url),
+      options.headers ?? {}
+    );
 
     const fetchOptions: RequestInit = {
       headers: mergedHeaders,

--- a/backend/src/services/__tests__/productAggregator.test.ts
+++ b/backend/src/services/__tests__/productAggregator.test.ts
@@ -303,7 +303,8 @@ test('merges default headers with merchant overrides before fetching', async (t)
 
   process.env.ELECTROPLANET_SEARCH_URL = 'https://electroplanet.test/catalog';
   process.env.ELECTROPLANET_HEADERS = JSON.stringify({
-    'User-Agent': 'AtlasBot/1.0',
+    'user-agent': 'AtlasBot/1.0',
+    'accept-language': 'en-GB,en;q=0.5',
     'X-Custom-Header': 'custom',
   });
 
@@ -345,15 +346,16 @@ test('merges default headers with merchant overrides before fetching', async (t)
       ? Object.fromEntries(headersInit)
       : { ...headersInit };
 
-  assert.equal(headers['User-Agent'], 'AtlasBot/1.0');
-  assert.equal(headers['X-Custom-Header'], 'custom');
+  const normalized = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  assert.equal(normalized['user-agent'], 'AtlasBot/1.0');
+  assert.equal(normalized['x-custom-header'], 'custom');
   assert.equal(
-    headers['Accept'],
+    normalized['accept'],
     'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
   );
-  assert.equal(
-    headers['Accept-Language'],
-    'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7'
-  );
-  assert.equal(headers['Referer'], 'https://electroplanet.test');
+  assert.equal(normalized['accept-language'], 'en-GB,en;q=0.5');
+  assert.equal(normalized['referer'], 'https://electroplanet.test');
 });


### PR DESCRIPTION
## Summary
- merge default HTTP headers with merchant-specific overrides in a case-insensitive manner
- extend the product aggregator integration test to assert the headers passed to fetch
- document how to override or disable default headers via the *_HEADERS environment variables

## Testing
- `npm run test:backend` *(fails: TypeScript compilation error unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dbed4451bc8325a54467b0731d18a6