### PR TITLE
Handle negative availability phrases

### DIFF
--- a/backend/src/integrations/__tests__/utils.test.ts
+++ b/backend/src/integrations/__tests__/utils.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseAvailability } from '../utils';
+
+test('parseAvailability handles negative availability phrases', () => {
+  const phrases = ['Indisponible', 'Produit non disponible', 'Article hors stock'];
+  for (const phrase of phrases) {
+    assert.equal(parseAvailability(phrase), 'out_of_stock');
+  }
+});

--- a/backend/src/integrations/utils.ts
+++ b/backend/src/integrations/utils.ts
@@ -245,6 +245,13 @@ export const parseAvailability = (value?: string | null) => {
   if (normalized.includes('rupture') || normalized.includes('epuise') || normalized.includes('out')) {
     return 'out_of_stock' as const;
   }
+  if (
+    normalized.includes('indisponible') ||
+    normalized.includes('non disponible') ||
+    normalized.includes('hors stock')
+  ) {
+    return 'out_of_stock' as const;
+  }
   if (normalized.includes('stock') || normalized.includes('available') || normalized.includes('disponible')) {
     return 'in_stock' as const;
   }


### PR DESCRIPTION
## Summary
- make parseAvailability classify negative French availability phrases as out_of_stock
- add unit coverage to lock in the new behaviour

## Testing
- npm run test:backend *(fails: TS2614: Module '"p-limit"' has no exported member 'Limit')*


------
https://chatgpt.com/codex/tasks/task_e_68dbed4558cc832582347bd30dd9b8eb