### PR TITLE
Refine availability parsing and fix cache imports

### DIFF
--- a/backend/src/integrations/__tests__/utils.test.ts
+++ b/backend/src/integrations/__tests__/utils.test.ts
@@ -9,3 +9,14 @@ test('parseAvailability handles negative availability phrases', () => {
     assert.equal(parseAvailability(phrase), 'out_of_stock');
   }
 });
+
+test('parseAvailability handles positive availability phrases', () => {
+  const phrases = [
+    'Disponible en boutique',
+    'Produit disponible en magasin',
+    'Retrait magasin disponible',
+  ];
+  for (const phrase of phrases) {
+    assert.equal(parseAvailability(phrase), 'in_stock');
+  }
+});

--- a/backend/src/integrations/utils.ts
+++ b/backend/src/integrations/utils.ts
@@ -266,14 +266,21 @@ export const parseAvailability = (value?: string | null) => {
     return 'unknown' as const;
   }
   const normalized = normalizeText(value);
-  if (normalized.includes('rupture') || normalized.includes('epuise') || normalized.includes('out')) {
-    return 'out_of_stock' as const;
-  }
-  if (
-    normalized.includes('indisponible') ||
-    normalized.includes('non disponible') ||
-    normalized.includes('hors stock')
-  ) {
+  const negativePhrases = [
+    'out of stock',
+    'out-of-stock',
+    'rupture de stock',
+    'en rupture de stock',
+    'en rupture',
+    'stock epuise',
+    'stock epuisee',
+    'epuise',
+    'epuisee',
+    'indisponible',
+    'non disponible',
+    'hors stock',
+  ];
+  if (negativePhrases.some((phrase) => normalized.includes(phrase))) {
     return 'out_of_stock' as const;
   }
   if (normalized.includes('stock') || normalized.includes('available') || normalized.includes('disponible')) {


### PR DESCRIPTION
## Summary
- restrict negative availability parsing to explicit phrases while keeping positive matches intact
- add positive availability test cases to guard against regressions
- adjust product aggregator imports to work with current p-limit and lru-cache modules

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dbf1a4aaf8832597fbb33cbc8a331d