### PR TITLE
feat: add Google Products API integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,17 @@ PORT=3001
 
 # PostgreSQL connection string used by Prisma and the API
 DATABASE_URL="postgresql://atlas_user:atlas_password@localhost:5432/atlas_taman?schema=public"
+
+# Google Products integration (optional)
+# Uncomment and configure these variables to enable the Google Shopping API connector
+# GOOGLE_PRODUCTS_API_URL="https://www.googleapis.com/customsearch/v1"
+# GOOGLE_PRODUCTS_API_KEY="your-api-key"
+# GOOGLE_PRODUCTS_SEARCH_ENGINE_ID="your-search-engine-id"
+# GOOGLE_PRODUCTS_COUNTRY="ma"
+# GOOGLE_PRODUCTS_LANGUAGE="fr"
+# GOOGLE_PRODUCTS_RESULTS_LIMIT=10
+# GOOGLE_PRODUCTS_TIMEOUT_MS=5000
+# GOOGLE_PRODUCTS_DEFAULT_CURRENCY=MAD
+# GOOGLE_PRODUCTS_API_KEY_PARAM=key
+# GOOGLE_PRODUCTS_API_KEY_HEADER="X-Api-Key"
+# GOOGLE_PRODUCTS_MERCHANT_URL="https://www.google.com/shopping"

--- a/backend/src/integrations/__tests__/googleProducts.test.ts
+++ b/backend/src/integrations/__tests__/googleProducts.test.ts
@@ -1,0 +1,237 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createGoogleProductsIntegration, isGoogleProductsIntegrationEnabled } from '../googleProducts';
+import type { MerchantIntegration } from '../types';
+import { ProductAggregator } from '../../services/productAggregator';
+
+const setEnv = (t: test.TestContext, key: string, value: string | undefined) => {
+  const previous = process.env[key];
+  if (typeof value === 'undefined') {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+
+  t.after(() => {
+    if (typeof previous === 'undefined') {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  });
+};
+
+const configureGoogleEnv = (t: test.TestContext) => {
+  setEnv(t, 'GOOGLE_PRODUCTS_API_URL', 'https://shopping.example/customsearch');
+  setEnv(t, 'GOOGLE_PRODUCTS_API_KEY', 'secret-key');
+  setEnv(t, 'GOOGLE_PRODUCTS_API_KEY_PARAM', 'api_key');
+  setEnv(t, 'GOOGLE_PRODUCTS_API_KEY_HEADER', 'X-Api-Key');
+  setEnv(t, 'GOOGLE_PRODUCTS_SEARCH_ENGINE_ID', 'engine-123');
+  setEnv(t, 'GOOGLE_PRODUCTS_COUNTRY', 'ma');
+  setEnv(t, 'GOOGLE_PRODUCTS_LANGUAGE', 'fr');
+  setEnv(t, 'GOOGLE_PRODUCTS_RESULTS_LIMIT', '10');
+  setEnv(t, 'GOOGLE_PRODUCTS_TIMEOUT_MS', '5000');
+  setEnv(t, 'GOOGLE_PRODUCTS_DEFAULT_CURRENCY', 'mad');
+  setEnv(t, 'GOOGLE_PRODUCTS_MERCHANT_URL', 'https://www.google.com/shopping');
+};
+
+test('creates offers sorted by total price using Google Products API', async (t) => {
+  configureGoogleEnv(t);
+
+  const apiResponse = {
+    items: [
+      {
+        productId: 'sku-001',
+        slug: 'iphone-15-pro',
+        title: 'Apple iPhone 15 Pro',
+        link: 'https://merchant-one.example/iphone-15-pro',
+        image: 'https://merchant-one.example/iphone-15-pro.jpg',
+        price: { value: 11999, currency: 'MAD' },
+        shipping: { value: 49 },
+        availability: 'In stock',
+        brand: 'Apple',
+        category: 'Smartphones',
+        merchant: {
+          id: 'merchant-one',
+          name: 'Merchant One',
+          url: 'https://merchant-one.example',
+        },
+      },
+      {
+        productId: 'sku-002',
+        slug: 'iphone-15-pro',
+        title: 'Apple iPhone 15 Pro (512GB)',
+        link: 'https://merchant-two.example/iphone-15-pro',
+        price: '12 499 MAD',
+        shipping: 'Livraison 29 MAD',
+        availability: 'Disponible',
+        brand: 'Apple',
+        category: 'Smartphones',
+        merchant: {
+          name: 'Merchant Two',
+        },
+      },
+    ],
+  };
+
+  const fetchCalls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  const originalFetch = globalThis.fetch;
+  const fetchMock: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push({ url, init });
+    return new Response(JSON.stringify(apiResponse), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  globalThis.fetch = fetchMock;
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  assert.equal(isGoogleProductsIntegrationEnabled(), true);
+  const integration = createGoogleProductsIntegration();
+  const offers = await integration.search('iPhone 15 Pro');
+
+  assert.equal(offers.length, 2);
+  const [firstOffer, secondOffer] = offers;
+
+  assert.equal(firstOffer.merchant.name, 'Merchant One');
+  assert.equal(firstOffer.price, 11999);
+  assert.equal(firstOffer.shippingFee, 49);
+  assert.equal(firstOffer.currency, 'MAD');
+  assert.equal(firstOffer.slug, 'iphone-15-pro');
+
+  const firstTotal = firstOffer.price + (firstOffer.shippingFee ?? 0);
+  const secondTotal = secondOffer.price + (secondOffer.shippingFee ?? 0);
+  assert.ok(firstTotal <= secondTotal, 'offers should be sorted by total price');
+
+  assert.equal(secondOffer.merchant.name, 'Merchant Two');
+  assert.equal(secondOffer.currency, 'MAD');
+  assert.equal(secondOffer.availability, 'in_stock');
+
+  assert.equal(fetchCalls.length, 1);
+  const [{ url, init }] = fetchCalls;
+  const requestUrl = new URL(url);
+  assert.equal(requestUrl.searchParams.get('api_key'), 'secret-key');
+  assert.equal(requestUrl.searchParams.get('q'), 'iPhone 15 Pro');
+  assert.equal(requestUrl.searchParams.get('cx'), 'engine-123');
+  assert.equal(requestUrl.searchParams.get('gl'), 'ma');
+  assert.equal(requestUrl.searchParams.get('hl'), 'fr');
+  assert.equal(requestUrl.searchParams.get('num'), '10');
+
+  assert.ok(init?.headers, 'expected headers to be set');
+  const rawHeaders = init?.headers;
+  const headers = rawHeaders instanceof Headers
+    ? Object.fromEntries(rawHeaders.entries())
+    : Array.isArray(rawHeaders)
+    ? Object.fromEntries(rawHeaders)
+    : { ...((rawHeaders as Record<string, string>) ?? {}) };
+
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  assert.equal(normalizedHeaders['x-api-key'], 'secret-key');
+});
+
+test('throws a descriptive error when the Google Products API fails', async (t) => {
+  configureGoogleEnv(t);
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response('quota exceeded', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const integration = createGoogleProductsIntegration();
+  await assert.rejects(() => integration.search('iphone 15'), /status 500: quota exceeded/);
+});
+
+test('product aggregator falls back to Google Products when scrapers fail', async (t) => {
+  configureGoogleEnv(t);
+
+  const apiResponse = {
+    items: [
+      {
+        productId: 'sku-101',
+        slug: 'iphone-15-pro',
+        title: 'Apple iPhone 15 Pro',
+        link: 'https://merchant-one.example/iphone-15-pro',
+        price: { value: 12499, currency: 'MAD' },
+        shipping: { value: 0 },
+        availability: 'In Stock',
+        merchant: {
+          id: 'merchant-one',
+          name: 'Merchant One',
+          url: 'https://merchant-one.example',
+        },
+      },
+      {
+        productId: 'sku-102',
+        slug: 'iphone-15-pro',
+        title: 'Apple iPhone 15 Pro (256GB)',
+        link: 'https://merchant-two.example/iphone-15-pro',
+        price: { value: 12999, currency: 'MAD' },
+        shipping: { value: 99 },
+        availability: 'Disponible',
+        merchant: {
+          name: 'Merchant Two',
+        },
+      },
+    ],
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify(apiResponse), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const failingIntegration: MerchantIntegration = {
+    id: 'failing-scraper',
+    label: 'Failing Scraper',
+    profile: {
+      id: 'failing-scraper',
+      name: 'Failing Scraper',
+      url: 'https://failing.example',
+    },
+    async search() {
+      throw new Error('Scraper timeout');
+    },
+  };
+
+  const googleIntegration = createGoogleProductsIntegration();
+  const aggregator = new ProductAggregator({
+    integrations: [failingIntegration, googleIntegration],
+    cacheTtlMs: 0,
+    rateLimitMs: 0,
+  });
+
+  const { products, errors, metadata } = await aggregator.search('iphone 15 pro');
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].merchantId, 'failing-scraper');
+  assert.equal(products.length, 1);
+
+  const [product] = products;
+  assert.equal(product.slug, 'iphone-15-pro');
+  assert.equal(product.offersCount, 2);
+  assert.equal(product.offers[0].merchant.name, 'Merchant One');
+  assert.equal(product.offers[1].merchant.name, 'Merchant Two');
+  assert.equal(product.minTotalPrice, product.offers[0].totalPrice);
+
+  const googleMetric = metadata.integrations.find((metric) => metric.id === 'google-products');
+  assert.ok(googleMetric, 'expected Google Products integration metric');
+  assert.equal(googleMetric?.offers, 2);
+});

--- a/backend/src/integrations/googleProducts.ts
+++ b/backend/src/integrations/googleProducts.ts
@@ -1,0 +1,375 @@
+import { MerchantIntegration, MerchantOffer, MerchantProfile } from './types';
+import { normalizeText, parseAvailability, slugify } from './utils';
+
+const INTEGRATION_ID = 'google-products';
+
+interface GoogleProductsConfig {
+  apiUrl: string;
+  apiKey: string;
+  apiKeyQueryParam: string;
+  apiKeyHeaderName?: string;
+  searchEngineId?: string;
+  country?: string;
+  language?: string;
+  resultsLimit?: number;
+  timeoutMs?: number;
+  defaultCurrency: string;
+  merchantUrl: string;
+}
+
+interface GoogleProductsMerchant {
+  id?: string;
+  name?: string;
+  url?: string;
+  logoUrl?: string;
+  city?: string;
+}
+
+interface GoogleProductsPriceObject {
+  value?: number | string;
+  currency?: string;
+}
+
+interface GoogleProductsShippingObject {
+  value?: number | string;
+  currency?: string;
+}
+
+interface GoogleProductsItem {
+  id?: string;
+  productId?: string;
+  slug?: string;
+  title?: string;
+  description?: string;
+  link?: string;
+  url?: string;
+  productUrl?: string;
+  image?: string;
+  images?: string[];
+  thumbnail?: string;
+  brand?: string;
+  category?: string;
+  price?: number | string | GoogleProductsPriceObject;
+  salePrice?: number | string | GoogleProductsPriceObject;
+  shipping?: number | string | GoogleProductsShippingObject;
+  availability?: string;
+  merchant?: GoogleProductsMerchant;
+  currency?: string;
+}
+
+interface GoogleProductsResponse {
+  items?: GoogleProductsItem[];
+}
+
+const parseInteger = (value?: string) => {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const resolveConfig = (): GoogleProductsConfig | null => {
+  const apiUrl = process.env.GOOGLE_PRODUCTS_API_URL;
+  const apiKey = process.env.GOOGLE_PRODUCTS_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    return null;
+  }
+
+  const apiKeyQueryParam = process.env.GOOGLE_PRODUCTS_API_KEY_PARAM ?? 'key';
+  const apiKeyHeaderName = process.env.GOOGLE_PRODUCTS_API_KEY_HEADER;
+  const searchEngineId = process.env.GOOGLE_PRODUCTS_SEARCH_ENGINE_ID;
+  const country = process.env.GOOGLE_PRODUCTS_COUNTRY;
+  const language = process.env.GOOGLE_PRODUCTS_LANGUAGE;
+  const resultsLimit = parseInteger(process.env.GOOGLE_PRODUCTS_RESULTS_LIMIT);
+  const timeoutMs = parseInteger(process.env.GOOGLE_PRODUCTS_TIMEOUT_MS);
+  const defaultCurrency = (process.env.GOOGLE_PRODUCTS_DEFAULT_CURRENCY ?? 'MAD').toUpperCase();
+  const merchantUrl = process.env.GOOGLE_PRODUCTS_MERCHANT_URL ?? 'https://www.google.com/shopping';
+
+  return {
+    apiUrl,
+    apiKey,
+    apiKeyQueryParam,
+    apiKeyHeaderName: apiKeyHeaderName || undefined,
+    searchEngineId: searchEngineId || undefined,
+    country: country || undefined,
+    language: language || undefined,
+    resultsLimit: resultsLimit || undefined,
+    timeoutMs: timeoutMs || undefined,
+    defaultCurrency,
+    merchantUrl,
+  };
+};
+
+const toNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const sanitized = value
+      .replace(/[^0-9,\.\-]/g, '')
+      .replace(/,/g, '.')
+      .replace(/\.(?=.*\.)/g, '');
+    const parsed = Number.parseFloat(sanitized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const record = value as GoogleProductsPriceObject;
+    return toNumber(record.value);
+  }
+
+  return undefined;
+};
+
+const toCurrency = (value: unknown, fallback: string): string => {
+  if (typeof value === 'string' && value.trim()) {
+    const letters = value.trim().match(/[A-Z]{3}/i)?.[0];
+    if (letters) {
+      return letters.toUpperCase();
+    }
+    return value.trim().toUpperCase();
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const record = value as GoogleProductsPriceObject;
+    if (typeof record.currency === 'string' && record.currency.trim()) {
+      return record.currency.trim().toUpperCase();
+    }
+  }
+
+  return fallback;
+};
+
+const buildMerchantProfile = (
+  item: GoogleProductsItem,
+  fallback: MerchantProfile,
+  index: number
+): MerchantProfile => {
+  const { merchant } = item;
+  if (!merchant) {
+    return fallback;
+  }
+
+  const merchantName = merchant.name?.trim();
+  if (!merchantName) {
+    return fallback;
+  }
+
+  const merchantIdSource = merchant.id ?? merchant.name;
+  const merchantIdSlug = slugify(merchantIdSource ?? merchantName);
+  const merchantUrl = merchant.url ?? item.link ?? item.url ?? fallback.url;
+
+  return {
+    id: merchantIdSlug || `${fallback.id}-merchant-${index}`,
+    name: merchantName,
+    url: merchantUrl,
+    logoUrl: merchant.logoUrl || undefined,
+    city: merchant.city || undefined,
+  };
+};
+
+const resolveImage = (item: GoogleProductsItem) =>
+  item.image ?? item.images?.[0] ?? item.thumbnail ?? undefined;
+
+const resolveProductUrl = (item: GoogleProductsItem, fallback: string) => {
+  const candidates = [item.link, item.url, item.productUrl];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate;
+    }
+  }
+  return fallback;
+};
+
+const normalizeItem = (
+  item: GoogleProductsItem,
+  config: GoogleProductsConfig,
+  fallbackProfile: MerchantProfile,
+  index: number
+): MerchantOffer | null => {
+  const title = item.title?.trim();
+  if (!title) {
+    return null;
+  }
+
+  const priceValue = toNumber(item.salePrice ?? item.price);
+  if (typeof priceValue !== 'number' || priceValue <= 0) {
+    return null;
+  }
+
+  const currency = toCurrency(item.salePrice ?? item.price ?? item.currency, config.defaultCurrency);
+  const productUrl = resolveProductUrl(item, fallbackProfile.url);
+  const productId = item.productId ?? item.id ?? productUrl;
+  const slugSource = item.slug ?? item.productId ?? title;
+  const slug = slugify(slugSource || title);
+  if (!slug) {
+    return null;
+  }
+
+  const merchantProfile = buildMerchantProfile(item, fallbackProfile, index);
+  const shippingFee = toNumber(item.shipping);
+  const availability = parseAvailability(item.availability);
+  const now = new Date().toISOString();
+
+  return {
+    offerId: `${merchantProfile.id}-${productId}`,
+    merchant: merchantProfile,
+    productId: String(productId),
+    slug,
+    title,
+    brand: item.brand ?? undefined,
+    category: item.category ?? undefined,
+    image: resolveImage(item),
+    price: priceValue,
+    currency,
+    shippingFee: typeof shippingFee === 'number' ? shippingFee : undefined,
+    availability,
+    url: productUrl,
+    scrapedAt: now,
+  };
+};
+
+const createRequestUrl = (query: string, config: GoogleProductsConfig) => {
+  const url = new URL(config.apiUrl);
+  url.searchParams.set(config.apiKeyQueryParam, config.apiKey);
+  url.searchParams.set('q', query);
+
+  if (config.searchEngineId) {
+    url.searchParams.set('cx', config.searchEngineId);
+  }
+  if (config.country) {
+    url.searchParams.set('gl', config.country);
+  }
+  if (config.language) {
+    url.searchParams.set('hl', config.language);
+  }
+  if (config.resultsLimit && config.resultsLimit > 0) {
+    url.searchParams.set('num', String(config.resultsLimit));
+  }
+
+  return url.toString();
+};
+
+const fetchWithTimeout = async (
+  url: string,
+  timeoutMs: number | undefined,
+  config: GoogleProductsConfig
+) => {
+  const controller = typeof timeoutMs === 'number' && timeoutMs > 0 ? new AbortController() : undefined;
+  const timeoutId = controller
+    ? setTimeout(() => {
+        controller.abort();
+      }, timeoutMs)
+    : undefined;
+
+  try {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+    };
+
+    if (config.apiKeyHeaderName) {
+      headers[config.apiKeyHeaderName] = config.apiKey;
+    }
+
+    const response = await fetch(url, {
+      headers,
+      signal: controller?.signal,
+    });
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Timeout after ${timeoutMs}ms when calling Google Products API`);
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+const defaultProfile: MerchantProfile = {
+  id: INTEGRATION_ID,
+  name: 'Google Products',
+  url: 'https://www.google.com/shopping',
+  logoUrl: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png',
+};
+
+const hasMeaningfulContent = (query: string) => /[a-z0-9]/.test(normalizeText(query));
+
+export const isGoogleProductsIntegrationEnabled = () => resolveConfig() !== null;
+
+export const createGoogleProductsIntegration = (): MerchantIntegration => {
+  const config = resolveConfig();
+  if (!config) {
+    throw new Error('Google Products integration is not configured.');
+  }
+
+  const profile: MerchantProfile = {
+    ...defaultProfile,
+    url: config.merchantUrl || defaultProfile.url,
+  };
+
+  return {
+    id: INTEGRATION_ID,
+    label: 'Google Products',
+    profile,
+    async search(query: string) {
+      const trimmed = query.trim();
+      if (!trimmed) {
+        return [];
+      }
+
+      if (!hasMeaningfulContent(trimmed)) {
+        return [];
+      }
+
+      const requestUrl = createRequestUrl(trimmed, config);
+      const response = await fetchWithTimeout(requestUrl, config.timeoutMs, config);
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        const suffix = body ? `: ${body}` : '';
+        throw new Error(`Google Products API request failed with status ${response.status}${suffix}`);
+      }
+
+      const data = (await response.json()) as GoogleProductsResponse;
+      const items = Array.isArray(data.items) ? data.items : [];
+
+      const offers: MerchantOffer[] = [];
+      for (const [index, item] of items.entries()) {
+        const offer = normalizeItem(item, config, profile, index);
+        if (offer) {
+          offers.push(offer);
+        }
+      }
+
+      offers.sort((a, b) => {
+        const totalA = a.price + (a.shippingFee ?? 0);
+        const totalB = b.price + (b.shippingFee ?? 0);
+        if (totalA === totalB) {
+          return a.title.localeCompare(b.title);
+        }
+        return totalA - totalB;
+      });
+
+      return offers;
+    },
+  };
+};
+
+export const maybeCreateGoogleProductsIntegration = () => {
+  if (!isGoogleProductsIntegrationEnabled()) {
+    return null;
+  }
+  try {
+    return createGoogleProductsIntegration();
+  } catch (error) {
+    return null;
+  }
+};

--- a/backend/src/integrations/index.ts
+++ b/backend/src/integrations/index.ts
@@ -1,19 +1,29 @@
 import { bimIntegration } from './bim';
 import { decathlonIntegration } from './decathlon';
 import { electroplanetIntegration } from './electroplanet';
+import { maybeCreateGoogleProductsIntegration } from './googleProducts';
 import { hmIntegration } from './hm';
 import { jumiaIntegration } from './jumia';
 import { marjaneIntegration } from './marjane';
 import { MerchantIntegration } from './types';
 
-export const createDefaultIntegrations = (): MerchantIntegration[] => [
-  electroplanetIntegration,
-  jumiaIntegration,
-  marjaneIntegration,
-  bimIntegration,
-  decathlonIntegration,
-  hmIntegration,
-];
+export const createDefaultIntegrations = (): MerchantIntegration[] => {
+  const integrations: MerchantIntegration[] = [
+    electroplanetIntegration,
+    jumiaIntegration,
+    marjaneIntegration,
+    bimIntegration,
+    decathlonIntegration,
+    hmIntegration,
+  ];
+
+  const googleIntegration = maybeCreateGoogleProductsIntegration();
+  if (googleIntegration) {
+    integrations.push(googleIntegration);
+  }
+
+  return integrations;
+};
 
 export * from './types';
 export * from './electroplanet';
@@ -22,3 +32,4 @@ export * from './marjane';
 export * from './bim';
 export * from './decathlon';
 export * from './hm';
+export * from './googleProducts';


### PR DESCRIPTION
## Summary
- add a Google Products integration that normalises API responses into merchant offers
- activate the connector when configured and document the required environment variables
- cover the new integration with unit tests, including aggregator fallback behaviour

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68dbf733c4988325a5415f1f4b030e55