### PR TITLE
Ensure backend server loads dotenv configuration first

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,7 @@
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
 import { productAggregator, AggregatedProduct } from './services/productAggregator';
-
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- load environment variables by importing `dotenv/config` before other backend server dependencies

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68dbfab1da608325ac7b2dbb2c12adbe