### PR TITLE
Add Cloudflare bypass fallback for merchant integrations

### DIFF
--- a/backend/src/integrations/__tests__/cloudflareBypass.test.ts
+++ b/backend/src/integrations/__tests__/cloudflareBypass.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { electroplanetIntegration } from '../electroplanet';
+
+const createFallbackHtml = () => `
+<html>
+  <body>
+    <ul class="products">
+      <li class="product-item" data-product-id="test-123">
+        <div class="product-item-info" data-product-id="test-123">
+          <a class="product-item-link" href="/produit/test-123">Test Product</a>
+          <div class="product-brand">TestBrand</div>
+          <div class="product-category">Smartphones</div>
+          <div class="price-box">
+            <span class="price" data-price-currency="MAD">1 234,00 DH</span>
+          </div>
+          <img src="/media/test-product.jpg" />
+          <div class="shipping">Livraison gratuite</div>
+          <div class="stock">En stock</div>
+        </div>
+      </li>
+    </ul>
+  </body>
+</html>
+`;
+
+test('electroplanetIntegration falls back to solver when Cloudflare blocks the request', async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalProvider = process.env.MERCHANT_SOLVER_PROVIDER;
+  const originalScrapingBeeKey = process.env.SCRAPINGBEE_API_KEY;
+  const originalScrapingBeeBase = process.env.SCRAPINGBEE_BASE_URL;
+  const originalScrapingBeeRender = process.env.SCRAPINGBEE_RENDER_JS;
+
+  const fallbackHtml = createFallbackHtml();
+  let callCount = 0;
+
+  const challengeResponse = new Response('<html><body><div class="cf-chl">Attention Required</div></body></html>', {
+    status: 503,
+    headers: { 'content-type': 'text/html' },
+  });
+
+  const fetchMock: typeof fetch = async (input) => {
+    callCount += 1;
+    if (callCount === 1) {
+      return challengeResponse;
+    }
+
+    const url = typeof input === 'string' ? input : input.toString();
+    assert.ok(url.startsWith('https://solver.example.com/'), 'expected solver endpoint to be called');
+    return new Response(fallbackHtml, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+  };
+
+  globalThis.fetch = fetchMock;
+  process.env.MERCHANT_SOLVER_PROVIDER = 'scrapingbee';
+  process.env.SCRAPINGBEE_API_KEY = 'test-api-key';
+  process.env.SCRAPINGBEE_BASE_URL = 'https://solver.example.com/';
+  process.env.SCRAPINGBEE_RENDER_JS = 'false';
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalProvider === undefined) {
+      delete process.env.MERCHANT_SOLVER_PROVIDER;
+    } else {
+      process.env.MERCHANT_SOLVER_PROVIDER = originalProvider;
+    }
+    if (originalScrapingBeeKey === undefined) {
+      delete process.env.SCRAPINGBEE_API_KEY;
+    } else {
+      process.env.SCRAPINGBEE_API_KEY = originalScrapingBeeKey;
+    }
+    if (originalScrapingBeeBase === undefined) {
+      delete process.env.SCRAPINGBEE_BASE_URL;
+    } else {
+      process.env.SCRAPINGBEE_BASE_URL = originalScrapingBeeBase;
+    }
+    if (originalScrapingBeeRender === undefined) {
+      delete process.env.SCRAPINGBEE_RENDER_JS;
+    } else {
+      process.env.SCRAPINGBEE_RENDER_JS = originalScrapingBeeRender;
+    }
+  });
+
+  const results = await electroplanetIntegration.search('iphone');
+
+  assert.equal(callCount, 2);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].title, 'Test Product');
+  assert.equal(results[0].price, 1234);
+  assert.equal(results[0].merchant.id, 'electroplanet');
+});

--- a/backend/src/integrations/bim.ts
+++ b/backend/src/integrations/bim.ts
@@ -140,16 +140,30 @@ export const bimIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response, failed, fallbackHtml } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    let html: string | undefined;
+
+    if (failed) {
+      if (!fallbackHtml) {
+        throw new Error(
+          `HTTP ${response.status} when fetching ${profile.id} catalogue (challenge not bypassed)`
+        );
+      }
+      html = fallbackHtml;
+    } else {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+      }
+      html = await response.text();
     }
 
-    const html = await response.text();
+    if (!html) {
+      throw new Error(`Empty response when fetching ${profile.id} catalogue`);
+    }
     return parseBimOffers(html, { origin: config.origin, currency: config.currency });
   },
 };

--- a/backend/src/integrations/cloudflareBypass.ts
+++ b/backend/src/integrations/cloudflareBypass.ts
@@ -1,0 +1,165 @@
+import { URL } from 'node:url';
+
+const SCRAPINGBEE_DEFAULT_BASE_URL = 'https://app.scrapingbee.com/api/v1/';
+
+export interface SolveMerchantRequestParams {
+  url: string;
+  headers: Record<string, string>;
+  status: number;
+  challengeBody?: string;
+}
+
+const readJsonFromResponse = async (response: Response) => {
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+const solveWithScrapingBee = async (
+  params: SolveMerchantRequestParams
+): Promise<string | undefined> => {
+  const apiKey = process.env.SCRAPINGBEE_API_KEY;
+  if (!apiKey) {
+    return undefined;
+  }
+
+  const baseUrl = process.env.SCRAPINGBEE_BASE_URL ?? SCRAPINGBEE_DEFAULT_BASE_URL;
+  let requestUrl: URL;
+  try {
+    requestUrl = new URL(baseUrl);
+  } catch (error) {
+    requestUrl = new URL(SCRAPINGBEE_DEFAULT_BASE_URL);
+  }
+
+  requestUrl.searchParams.set('api_key', apiKey);
+  requestUrl.searchParams.set('url', params.url);
+  requestUrl.searchParams.set('render_js', process.env.SCRAPINGBEE_RENDER_JS ?? 'false');
+
+  if (process.env.SCRAPINGBEE_COUNTRY_CODE) {
+    requestUrl.searchParams.set('country_code', process.env.SCRAPINGBEE_COUNTRY_CODE);
+  }
+  if (process.env.SCRAPINGBEE_PREMIUM_PROXY) {
+    requestUrl.searchParams.set('premium_proxy', process.env.SCRAPINGBEE_PREMIUM_PROXY);
+  }
+  if (process.env.SCRAPINGBEE_BLOCK_RESOURCES) {
+    requestUrl.searchParams.set('block_resources', process.env.SCRAPINGBEE_BLOCK_RESOURCES);
+  }
+
+  const response = await fetch(requestUrl, {
+    headers: { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  return await response.text();
+};
+
+const solveWithHttpEndpoint = async (
+  params: SolveMerchantRequestParams,
+  endpoint: string,
+  additionalHeaders: Record<string, string> = {}
+): Promise<string | undefined> => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...additionalHeaders,
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      url: params.url,
+      headers: params.headers,
+      status: params.status,
+      html: params.challengeBody,
+    }),
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    const payload = await readJsonFromResponse(response);
+    if (!payload) {
+      return undefined;
+    }
+    const htmlValue =
+      payload.html ?? payload.content ?? payload.result ?? payload.body ?? payload.data;
+    return typeof htmlValue === 'string' ? htmlValue : undefined;
+  }
+
+  return await response.text();
+};
+
+const solveWithBrightData = async (
+  params: SolveMerchantRequestParams
+): Promise<string | undefined> => {
+  const endpoint = process.env.BRIGHTDATA_COLLECTOR_URL ?? process.env.MERCHANT_SOLVER_ENDPOINT;
+  if (!endpoint) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {};
+  const token = process.env.BRIGHTDATA_API_TOKEN ?? process.env.MERCHANT_SOLVER_API_KEY;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const username = process.env.BRIGHTDATA_USERNAME;
+  const password = process.env.BRIGHTDATA_PASSWORD;
+  if (username && password) {
+    const credentials = Buffer.from(`${username}:${password}`).toString('base64');
+    headers.Authorization = `Basic ${credentials}`;
+  }
+
+  return await solveWithHttpEndpoint(params, endpoint, headers);
+};
+
+const solveWithCustomEndpoint = async (
+  params: SolveMerchantRequestParams
+): Promise<string | undefined> => {
+  const endpoint = process.env.MERCHANT_SOLVER_ENDPOINT;
+  if (!endpoint) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {};
+  const apiKey = process.env.MERCHANT_SOLVER_API_KEY;
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  return await solveWithHttpEndpoint(params, endpoint, headers);
+};
+
+export const solveMerchantRequest = async (
+  params: SolveMerchantRequestParams
+): Promise<string | undefined> => {
+  const provider = process.env.MERCHANT_SOLVER_PROVIDER?.toLowerCase();
+  if (!provider) {
+    return undefined;
+  }
+
+  try {
+    switch (provider) {
+      case 'scrapingbee':
+        return await solveWithScrapingBee(params);
+      case 'brightdata':
+        return await solveWithBrightData(params);
+      case 'browser':
+      case 'custom':
+      case 'http':
+        return await solveWithCustomEndpoint(params);
+      default:
+        return undefined;
+    }
+  } catch (error) {
+    return undefined;
+  }
+};

--- a/backend/src/integrations/decathlon.ts
+++ b/backend/src/integrations/decathlon.ts
@@ -146,16 +146,30 @@ export const decathlonIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response, failed, fallbackHtml } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    let html: string | undefined;
+
+    if (failed) {
+      if (!fallbackHtml) {
+        throw new Error(
+          `HTTP ${response.status} when fetching ${profile.id} catalogue (challenge not bypassed)`
+        );
+      }
+      html = fallbackHtml;
+    } else {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+      }
+      html = await response.text();
     }
 
-    const html = await response.text();
+    if (!html) {
+      throw new Error(`Empty response when fetching ${profile.id} catalogue`);
+    }
     return parseDecathlonOffers(html, { origin: config.origin, currency: config.currency });
   },
 };

--- a/backend/src/integrations/electroplanet.ts
+++ b/backend/src/integrations/electroplanet.ts
@@ -138,16 +138,30 @@ export const electroplanetIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response, failed, fallbackHtml } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    let html: string | undefined;
+
+    if (failed) {
+      if (!fallbackHtml) {
+        throw new Error(
+          `HTTP ${response.status} when fetching ${profile.id} catalogue (challenge not bypassed)`
+        );
+      }
+      html = fallbackHtml;
+    } else {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+      }
+      html = await response.text();
     }
 
-    const html = await response.text();
+    if (!html) {
+      throw new Error(`Empty response when fetching ${profile.id} catalogue`);
+    }
     return parseElectroplanetOffers(html, { origin: config.origin, currency: config.currency });
   },
 };

--- a/backend/src/integrations/hm.ts
+++ b/backend/src/integrations/hm.ts
@@ -145,16 +145,30 @@ export const hmIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response, failed, fallbackHtml } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    let html: string | undefined;
+
+    if (failed) {
+      if (!fallbackHtml) {
+        throw new Error(
+          `HTTP ${response.status} when fetching ${profile.id} catalogue (challenge not bypassed)`
+        );
+      }
+      html = fallbackHtml;
+    } else {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+      }
+      html = await response.text();
     }
 
-    const html = await response.text();
+    if (!html) {
+      throw new Error(`Empty response when fetching ${profile.id} catalogue`);
+    }
     return parseHmOffers(html, { origin: config.origin, currency: config.currency });
   },
 };

--- a/backend/src/integrations/jumia.ts
+++ b/backend/src/integrations/jumia.ts
@@ -137,16 +137,30 @@ export const jumiaIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response, failed, fallbackHtml } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    let html: string | undefined;
+
+    if (failed) {
+      if (!fallbackHtml) {
+        throw new Error(
+          `HTTP ${response.status} when fetching ${profile.id} catalogue (challenge not bypassed)`
+        );
+      }
+      html = fallbackHtml;
+    } else {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+      }
+      html = await response.text();
     }
 
-    const html = await response.text();
+    if (!html) {
+      throw new Error(`Empty response when fetching ${profile.id} catalogue`);
+    }
     return parseJumiaOffers(html, { origin: config.origin, currency: config.currency });
   },
 };

--- a/backend/src/integrations/marjane.ts
+++ b/backend/src/integrations/marjane.ts
@@ -143,16 +143,30 @@ export const marjaneIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response, failed, fallbackHtml } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+    let html: string | undefined;
+
+    if (failed) {
+      if (!fallbackHtml) {
+        throw new Error(
+          `HTTP ${response.status} when fetching ${profile.id} catalogue (challenge not bypassed)`
+        );
+      }
+      html = fallbackHtml;
+    } else {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} when fetching ${profile.id} catalogue`);
+      }
+      html = await response.text();
     }
 
-    const html = await response.text();
+    if (!html) {
+      throw new Error(`Empty response when fetching ${profile.id} catalogue`);
+    }
     return parseMarjaneOffers(html, { origin: config.origin, currency: config.currency });
   },
 };

--- a/backend/src/integrations/utils.ts
+++ b/backend/src/integrations/utils.ts
@@ -1,3 +1,4 @@
+import { solveMerchantRequest } from './cloudflareBypass';
 import { merchantProfiles } from './fixtures/merchantData';
 
 type MerchantId = keyof typeof merchantProfiles;
@@ -171,10 +172,60 @@ const mergeHeadersWithDefaults = (
   return merged;
 };
 
+const CLOUDFLARE_MARKERS = [
+  /cf-chl/i,
+  /attention required/i,
+  /cloudflare/i,
+  /verify you are human/i,
+  /just a moment/i,
+];
+
+export interface FetchWithConfigResult {
+  response: Response;
+  failed: boolean;
+  fallbackHtml?: string;
+}
+
+const shouldAttemptBypass = async (response: Response) => {
+  let cachedBody: string | undefined;
+  let bodyRead = false;
+
+  const readBody = async () => {
+    if (bodyRead) {
+      return cachedBody;
+    }
+    bodyRead = true;
+    try {
+      cachedBody = await response.clone().text();
+    } catch (error) {
+      cachedBody = undefined;
+    }
+    return cachedBody;
+  };
+
+  if (response.status === 403 || response.status === 503) {
+    const body = await readBody();
+    return { failed: true, body } as const;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('text/html')) {
+    return { failed: false, body: undefined } as const;
+  }
+
+  const body = await readBody();
+  if (!body) {
+    return { failed: false, body: undefined } as const;
+  }
+
+  const matchesChallenge = CLOUDFLARE_MARKERS.some((pattern) => pattern.test(body));
+  return { failed: matchesChallenge, body } as const;
+};
+
 export const fetchWithConfig = async (
   url: string,
   options: { headers?: Record<string, string>; timeoutMs?: number } = {}
-) => {
+): Promise<FetchWithConfigResult> => {
   const controller = options.timeoutMs ? new AbortController() : undefined;
   const timeoutId = options.timeoutMs
     ? setTimeout(() => controller?.abort(), options.timeoutMs)
@@ -195,7 +246,24 @@ export const fetchWithConfig = async (
     }
 
     const response = await fetch(url, fetchOptions);
-    return response;
+    const { failed, body } = await shouldAttemptBypass(response);
+
+    if (!failed) {
+      return { response, failed: false };
+    }
+
+    const fallbackHtml = await solveMerchantRequest({
+      url,
+      headers: mergedHeaders,
+      status: response.status,
+      challengeBody: body,
+    });
+
+    if (fallbackHtml) {
+      return { response, failed: true, fallbackHtml };
+    }
+
+    return { response, failed: true };
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
       throw new Error(`Timeout after ${options.timeoutMs}ms for ${url}`);


### PR DESCRIPTION
## Summary
- add a Cloudflare bypass helper capable of delegating blocked merchant requests to configurable external solvers
- extend fetchWithConfig and every merchant integration to consume solver HTML when the primary request is challenged
- cover the new fallback flow with unit tests simulating a Cloudflare 503 challenge

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68dd05bf38dc8325825bba45bb87dcfa