### PR TITLE
feat: add proxy support for merchant integrations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# Atlas Taman Backend
+
+## Variables d'environnement HTTP par marchand
+
+Chaque connecteur HTTP peut être personnalisé via des variables d'environnement préfixées par l'identifiant du marchand (ex. `ELECTROPLANET_`, `JUMIA_`, etc.).
+
+| Variable | Description |
+| --- | --- |
+| `*_SEARCH_URL` | URL de recherche par défaut. |
+| `*_QUERY_PARAM` | Paramètre de requête utilisé pour le terme recherché. |
+| `*_HEADERS` | En-têtes HTTP additionnels/alternatifs (JSON ou liste clé=valeur). |
+| `*_STATIC_PARAMS` | Paramètres de requête supplémentaires (JSON ou liste clé=valeur). |
+| `*_DELAY_MS` | Délai artificiel avant la requête (millisecondes). |
+| `*_TIMEOUT_MS` | Délai maximum pour la requête (millisecondes). |
+| `*_CURRENCY` | Devise par défaut retournée par le marchand. |
+| `*_PROXY_URL` | URL d'un proxy HTTP(s) facultatif utilisé pour les requêtes vers le marchand. |
+
+> ℹ️ Exemple : pour configurer un proxy sur Jumia, définissez `JUMIA_PROXY_URL="http://mon-proxy.local:3128"` dans le fichier `.env` du backend.

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "express": "^4.18.2",
     "htmlparser2": "^6.1.0",
     "lru-cache": "^10.2.0",
-    "p-limit": "^4.0.0"
+    "p-limit": "^4.0.0",
+    "undici": "^6.19.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/backend/src/integrations/__tests__/utils.test.ts
+++ b/backend/src/integrations/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
-import test from 'node:test';
+import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseAvailability } from '../utils';
+import { fetchWithConfig, parseAvailability } from '../utils';
 
 test('parseAvailability handles negative availability phrases', () => {
   const phrases = ['Indisponible', 'Produit non disponible', 'Article hors stock'];
@@ -19,4 +19,44 @@ test('parseAvailability handles positive availability phrases', () => {
   for (const phrase of phrases) {
     assert.equal(parseAvailability(phrase), 'in_stock');
   }
+});
+
+test('fetchWithConfig instancie un ProxyAgent lorsqu\'un proxy est défini', async () => {
+  const ProxyAgentMock = class ProxyAgent {
+    constructor(public proxyUrl: string) {}
+  };
+
+  mock.module('undici', {
+    cache: true,
+    defaultExport: { ProxyAgent: ProxyAgentMock },
+    namedExports: { ProxyAgent: ProxyAgentMock },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const dispatched: Array<{ dispatcher?: unknown }> = [];
+
+  globalThis.fetch = (async (
+    _input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1] & { dispatcher?: unknown }
+  ) => {
+    dispatched.push({ dispatcher: init?.dispatcher });
+    const response = {
+      ok: true,
+      text: async () => '',
+    } as unknown as Response;
+    return response;
+  }) as typeof fetch;
+
+  try {
+    await fetchWithConfig('https://example.com', {
+      proxyUrl: 'http://proxy.local:8080',
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    mock.restoreAll();
+  }
+
+  assert.equal(dispatched.length, 1);
+  assert.ok(dispatched[0]?.dispatcher instanceof ProxyAgentMock);
+  assert.equal((dispatched[0]?.dispatcher as { proxyUrl: string }).proxyUrl, 'http://proxy.local:8080');
 });

--- a/backend/src/integrations/bim.ts
+++ b/backend/src/integrations/bim.ts
@@ -143,6 +143,7 @@ export const bimIntegration: MerchantIntegration = {
     const response = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
+      proxyUrl: config.proxyUrl,
     });
 
     if (!response.ok) {

--- a/backend/src/integrations/decathlon.ts
+++ b/backend/src/integrations/decathlon.ts
@@ -149,6 +149,7 @@ export const decathlonIntegration: MerchantIntegration = {
     const response = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
+      proxyUrl: config.proxyUrl,
     });
 
     if (!response.ok) {

--- a/backend/src/integrations/electroplanet.ts
+++ b/backend/src/integrations/electroplanet.ts
@@ -141,6 +141,7 @@ export const electroplanetIntegration: MerchantIntegration = {
     const response = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
+      proxyUrl: config.proxyUrl,
     });
 
     if (!response.ok) {

--- a/backend/src/integrations/hm.ts
+++ b/backend/src/integrations/hm.ts
@@ -148,6 +148,7 @@ export const hmIntegration: MerchantIntegration = {
     const response = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
+      proxyUrl: config.proxyUrl,
     });
 
     if (!response.ok) {

--- a/backend/src/integrations/jumia.ts
+++ b/backend/src/integrations/jumia.ts
@@ -140,6 +140,7 @@ export const jumiaIntegration: MerchantIntegration = {
     const response = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
+      proxyUrl: config.proxyUrl,
     });
 
     if (!response.ok) {

--- a/backend/src/integrations/marjane.ts
+++ b/backend/src/integrations/marjane.ts
@@ -146,6 +146,7 @@ export const marjaneIntegration: MerchantIntegration = {
     const response = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
+      proxyUrl: config.proxyUrl,
     });
 
     if (!response.ok) {

--- a/backend/src/types/undici.d.ts
+++ b/backend/src/types/undici.d.ts
@@ -1,0 +1,9 @@
+declare module 'undici' {
+  export interface Dispatcher {
+    // The Dispatcher interface is intentionally left empty for the purposes of local type checking.
+  }
+
+  export class ProxyAgent implements Dispatcher {
+    constructor(proxyUrl: string);
+  }
+}


### PR DESCRIPTION
## Summary
- add optional proxyUrl to merchant HTTP configuration and lazily load the undici ProxyAgent when set
- propagate proxy options through all merchant integrations so requests can be routed via a proxy
- document the new *_PROXY_URL environment variable and cover proxy agent usage with a unit test

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dd05bea4e88325ae3ab9e8f66ac1de