### PR TITLE
Add Cloudflare fallback flow for HTTP integrations

### DIFF
--- a/backend/src/integrations/__tests__/cloudflareFallback.test.ts
+++ b/backend/src/integrations/__tests__/cloudflareFallback.test.ts
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchWithConfig } from '../utils';
+import { electroplanetIntegration } from '../electroplanet';
+
+const CLOUDFLARE_HTML = `<!doctype html>
+<html>
+  <head><title>Attention Required! | Cloudflare</title></head>
+  <body>
+    <div id="cf-error-details">
+      <span class="cf-error-title">Please enable cookies.</span>
+    </div>
+  </body>
+</html>`;
+
+test('fetchWithConfig utilise le fallback Cloudflare en cas de blocage', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = {
+    url: process.env.CLOUDFLARE_FALLBACK_URL,
+    apiKey: process.env.CLOUDFLARE_FALLBACK_API_KEY,
+    timeout: process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS,
+  };
+
+  const requests: Array<{
+    input: Parameters<typeof fetch>[0];
+    init?: Parameters<typeof fetch>[1];
+  }> = [];
+
+  process.env.CLOUDFLARE_FALLBACK_URL = 'https://solver.local/solve';
+  process.env.CLOUDFLARE_FALLBACK_API_KEY = 'fallback-key';
+  process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS = '2000';
+
+  globalThis.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ) => {
+    requests.push({ input, init });
+
+    if (typeof input === 'string' && input.startsWith('https://example.com')) {
+      return new Response(CLOUDFLARE_HTML, {
+        status: 503,
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+
+    if (input === 'https://solver.local/solve') {
+      return new Response(JSON.stringify({ html: '<html>ok</html>' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected request to ${String(input)}`);
+  }) as typeof fetch;
+
+  try {
+    const result = await fetchWithConfig('https://example.com/products', {});
+    assert.equal(result.wasBlocked, true);
+
+    const body = await result.response.text();
+    assert.equal(body, '<html>ok</html>');
+
+    assert.equal(requests.length, 2);
+    const fallbackHeaders = new Headers(requests[1]?.init?.headers);
+    assert.equal(fallbackHeaders.get('x-api-key'), 'fallback-key');
+    assert.equal(fallbackHeaders.get('content-type'), 'application/json');
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.CLOUDFLARE_FALLBACK_URL = originalEnv.url;
+    process.env.CLOUDFLARE_FALLBACK_API_KEY = originalEnv.apiKey;
+    process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS = originalEnv.timeout;
+  }
+});
+
+test('electroplanetIntegration récupère le HTML du fallback Cloudflare', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = {
+    url: process.env.CLOUDFLARE_FALLBACK_URL,
+    apiKey: process.env.CLOUDFLARE_FALLBACK_API_KEY,
+    timeout: process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS,
+  };
+
+  const fallbackHtml = `
+  <ul>
+    <li class="product-item" data-product-id="abc123">
+      <div class="product-item-info">
+        <a class="product-item-link" href="/produit/abc123">Laptop Pro</a>
+        <span class="price-box">
+          <span class="price" data-price-currency="MAD">1 299,00</span>
+        </span>
+      </div>
+    </li>
+  </ul>`;
+
+  const requests: Array<{
+    input: Parameters<typeof fetch>[0];
+    init?: Parameters<typeof fetch>[1];
+  }> = [];
+
+  process.env.CLOUDFLARE_FALLBACK_URL = 'https://solver.local/solve';
+  process.env.CLOUDFLARE_FALLBACK_API_KEY = undefined;
+  process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS = undefined;
+
+  globalThis.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ) => {
+    requests.push({ input, init });
+
+    if (typeof input === 'string' && input.includes('catalogsearch/result')) {
+      return new Response(CLOUDFLARE_HTML, {
+        status: 503,
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+
+    if (input === 'https://solver.local/solve') {
+      return new Response(JSON.stringify({ html: fallbackHtml }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected request to ${String(input)}`);
+  }) as typeof fetch;
+
+  try {
+    const offers = await electroplanetIntegration.search('Laptop');
+    assert.equal(offers.length, 1);
+    assert.equal(offers[0]?.title, 'Laptop Pro');
+    assert.equal(offers[0]?.price, 1299);
+    assert.equal(requests.length, 2);
+    assert.equal(new Headers(requests[1]?.init?.headers).get('x-api-key'), null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.CLOUDFLARE_FALLBACK_URL = originalEnv.url;
+    process.env.CLOUDFLARE_FALLBACK_API_KEY = originalEnv.apiKey;
+    process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS = originalEnv.timeout;
+  }
+});

--- a/backend/src/integrations/bim.ts
+++ b/backend/src/integrations/bim.ts
@@ -140,7 +140,7 @@ export const bimIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
       proxyUrl: config.proxyUrl,

--- a/backend/src/integrations/cloudflareFallback.ts
+++ b/backend/src/integrations/cloudflareFallback.ts
@@ -1,0 +1,196 @@
+const CLOUD_FLARE_PATTERNS: RegExp[] = [
+  /__cf_chl_jschl_tk__/i,
+  /cf-browser-verification/i,
+  /attention required!\s*\|\s*cloudflare/i,
+  /ddos protection by cloudflare/i,
+  /checking your browser before accessing/i,
+  /ray id/i,
+];
+
+const MAX_BODY_LENGTH = 64 * 1024;
+
+export type CloudflareBlockReason = 'status_code' | 'html_marker';
+
+export interface CloudflareBlockDetection {
+  blocked: boolean;
+  reason?: CloudflareBlockReason;
+  statusCode?: number;
+  bodyText?: string;
+}
+
+export interface CloudflareFallbackConfig {
+  solverUrl: string;
+  apiKey?: string;
+  timeoutMs?: number;
+}
+
+export interface CloudflareFallbackOverrides {
+  solverUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+}
+
+const readBodySafely = async (response: Response): Promise<string | undefined> => {
+  try {
+    return await response.text();
+  } catch (error) {
+    return undefined;
+  }
+};
+
+const sliceBody = (body?: string) => {
+  if (typeof body !== 'string') {
+    return undefined;
+  }
+  if (body.length <= MAX_BODY_LENGTH) {
+    return body;
+  }
+  return body.slice(0, MAX_BODY_LENGTH);
+};
+
+const resolveEnvNumber = (value?: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const buildFallbackConfig = (
+  overrides?: CloudflareFallbackOverrides
+): CloudflareFallbackConfig | undefined => {
+  const solverUrl = overrides?.solverUrl ?? process.env.CLOUDFLARE_FALLBACK_URL;
+  if (!solverUrl) {
+    return undefined;
+  }
+
+  const apiKey = overrides?.apiKey ?? process.env.CLOUDFLARE_FALLBACK_API_KEY;
+  const timeoutMs =
+    overrides?.timeoutMs ?? resolveEnvNumber(process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS);
+
+  return { solverUrl, apiKey, timeoutMs };
+};
+
+export const detectCloudflareBlock = async (
+  response: Response
+): Promise<CloudflareBlockDetection> => {
+  const statusCode = response.status;
+  const contentType = response.headers.get('content-type') ?? '';
+  const isHtml = /html/i.test(contentType);
+
+  if (statusCode === 403 || statusCode === 503) {
+    const bodyText = await readBodySafely(response.clone());
+    return {
+      blocked: true,
+      reason: 'status_code',
+      statusCode,
+      bodyText,
+    };
+  }
+
+  if (!isHtml) {
+    return { blocked: false };
+  }
+
+  const bodyText = await readBodySafely(response.clone());
+  if (!bodyText) {
+    return { blocked: false };
+  }
+
+  if (CLOUD_FLARE_PATTERNS.some((pattern) => pattern.test(bodyText))) {
+    return {
+      blocked: true,
+      reason: 'html_marker',
+      statusCode,
+      bodyText,
+    };
+  }
+
+  return { blocked: false };
+};
+
+export const triggerCloudflareFallback = async (
+  params: {
+    url: string;
+    headers: Record<string, string>;
+    detection: CloudflareBlockDetection;
+    overrides?: CloudflareFallbackOverrides;
+  },
+  fetchImpl: typeof fetch = fetch
+): Promise<Response | undefined> => {
+  const config = buildFallbackConfig(params.overrides);
+  if (!config) {
+    return undefined;
+  }
+
+  const controller = config.timeoutMs ? new AbortController() : undefined;
+  const timeoutId = config.timeoutMs
+    ? setTimeout(() => controller?.abort(), config.timeoutMs)
+    : undefined;
+
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  };
+
+  if (config.apiKey) {
+    (headers as Record<string, string>)['x-api-key'] = config.apiKey;
+  }
+
+  const payload = {
+    url: params.url,
+    headers: params.headers,
+    reason: params.detection.reason,
+    statusCode: params.detection.statusCode,
+    originalBody: sliceBody(params.detection.bodyText),
+  };
+
+  const requestInit: RequestInit = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+    signal: controller?.signal,
+  };
+
+  try {
+    const response = await fetchImpl(config.solverUrl, requestInit);
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    let html: string | undefined;
+
+    if (/json/i.test(contentType)) {
+      try {
+        const data = (await response.json()) as { html?: unknown };
+        if (typeof data?.html === 'string') {
+          html = data.html;
+        }
+      } catch (error) {
+        return undefined;
+      }
+    }
+
+    if (!html) {
+      html = await response.text();
+    }
+
+    if (!html) {
+      return undefined;
+    }
+
+    const fallbackHeaders = new Headers({
+      'content-type': 'text/html; charset=utf-8',
+      'x-atlas-cloudflare-fallback': '1',
+    });
+
+    return new Response(html, { status: 200, headers: fallbackHeaders });
+  } catch (error) {
+    return undefined;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};

--- a/backend/src/integrations/decathlon.ts
+++ b/backend/src/integrations/decathlon.ts
@@ -146,7 +146,7 @@ export const decathlonIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
       proxyUrl: config.proxyUrl,

--- a/backend/src/integrations/electroplanet.ts
+++ b/backend/src/integrations/electroplanet.ts
@@ -138,7 +138,7 @@ export const electroplanetIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
       proxyUrl: config.proxyUrl,

--- a/backend/src/integrations/hm.ts
+++ b/backend/src/integrations/hm.ts
@@ -145,7 +145,7 @@ export const hmIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
       proxyUrl: config.proxyUrl,

--- a/backend/src/integrations/jumia.ts
+++ b/backend/src/integrations/jumia.ts
@@ -137,7 +137,7 @@ export const jumiaIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
       proxyUrl: config.proxyUrl,

--- a/backend/src/integrations/marjane.ts
+++ b/backend/src/integrations/marjane.ts
@@ -143,7 +143,7 @@ export const marjaneIntegration: MerchantIntegration = {
     }
 
     const url = buildSearchUrl(config.searchUrl, config.queryParam, trimmedQuery, config.staticParams);
-    const response = await fetchWithConfig(url, {
+    const { response } = await fetchWithConfig(url, {
       headers: config.headers,
       timeoutMs: config.timeoutMs,
       proxyUrl: config.proxyUrl,


### PR DESCRIPTION
## Summary
- add a Cloudflare fallback helper that detects blocked pages and replays requests through the configured solver
- extend `fetchWithConfig` to return the fallback response metadata and update each HTTP integration to consume it
- add tests that simulate a Cloudflare 503 and ensure the fallback path still yields offers

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dd0b841e30832595d8655790d12964