### PR TITLE
Handle Cloudflare fallback raw HTML responses

### DIFF
--- a/backend/src/integrations/__tests__/cloudflareFallback.test.ts
+++ b/backend/src/integrations/__tests__/cloudflareFallback.test.ts
@@ -73,6 +73,64 @@ test('fetchWithConfig utilise le fallback Cloudflare en cas de blocage', async (
   }
 });
 
+test('fetchWithConfig utilise le HTML brut si le solver renvoie un JSON invalide', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = {
+    url: process.env.CLOUDFLARE_FALLBACK_URL,
+    apiKey: process.env.CLOUDFLARE_FALLBACK_API_KEY,
+    timeout: process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS,
+  };
+
+  const requests: Array<{
+    input: Parameters<typeof fetch>[0];
+    init?: Parameters<typeof fetch>[1];
+  }> = [];
+
+  process.env.CLOUDFLARE_FALLBACK_URL = 'https://solver.local/solve';
+  process.env.CLOUDFLARE_FALLBACK_API_KEY = undefined;
+  process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS = undefined;
+
+  const fallbackHtml = '<html>fallback</html>';
+
+  globalThis.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ) => {
+    requests.push({ input, init });
+
+    if (typeof input === 'string' && input.startsWith('https://example.com')) {
+      return new Response(CLOUDFLARE_HTML, {
+        status: 503,
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+
+    if (input === 'https://solver.local/solve') {
+      return new Response(fallbackHtml, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected request to ${String(input)}`);
+  }) as typeof fetch;
+
+  try {
+    const result = await fetchWithConfig('https://example.com/products', {});
+    assert.equal(result.wasBlocked, true);
+
+    const body = await result.response.text();
+    assert.equal(body, fallbackHtml);
+
+    assert.equal(requests.length, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.CLOUDFLARE_FALLBACK_URL = originalEnv.url;
+    process.env.CLOUDFLARE_FALLBACK_API_KEY = originalEnv.apiKey;
+    process.env.CLOUDFLARE_FALLBACK_TIMEOUT_MS = originalEnv.timeout;
+  }
+});
+
 test('electroplanetIntegration récupère le HTML du fallback Cloudflare', async () => {
   const originalFetch = globalThis.fetch;
   const originalEnv = {

--- a/backend/src/integrations/cloudflareFallback.ts
+++ b/backend/src/integrations/cloudflareFallback.ts
@@ -159,24 +159,25 @@ export const triggerCloudflareFallback = async (
     }
 
     const contentType = response.headers.get('content-type') ?? '';
+    const raw = await response.text();
     let html: string | undefined;
 
     if (/json/i.test(contentType)) {
       try {
-        const data = (await response.json()) as { html?: unknown };
+        const data = JSON.parse(raw) as { html?: unknown };
         if (typeof data?.html === 'string') {
           html = data.html;
         }
       } catch (error) {
-        return undefined;
+        html = undefined;
       }
     }
 
     if (!html) {
-      html = await response.text();
+      html = raw;
     }
 
-    if (!html) {
+    if (!html || html.trim().length === 0) {
       return undefined;
     }
 


### PR DESCRIPTION
## Summary
- avoid consuming the solver response stream twice by reading it once and parsing HTML from JSON when available
- fall back to the raw solver body for non-empty HTML payloads
- add a regression test covering invalid JSON payloads from the solver

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd10762af8832581ea14e405d0b051