### PR TITLE
Improve Cloudflare fallback HTML parsing

### DIFF
--- a/backend/src/integrations/cloudflareFallback.ts
+++ b/backend/src/integrations/cloudflareFallback.ts
@@ -11,6 +11,29 @@ const MAX_BODY_LENGTH = 64 * 1024;
 
 const SOLVER_HTML_KEYS = ['html', 'response'] as const;
 
+const SOLVER_KNOWN_PATHS: ReadonlyArray<ReadonlyArray<string>> = [
+  ['solution', 'response'],
+  ['solution', 'html'],
+  ['result', 'html'],
+  ['result', 'response'],
+  ['html'],
+  ['response'],
+];
+
+const getValueAtPath = (value: unknown, path: readonly string[]): unknown => {
+  let current: unknown = value;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+};
+
 const extractHtmlFromSolverPayload = (payload: unknown): string | undefined => {
   if (typeof payload === 'string') {
     return payload;
@@ -18,6 +41,13 @@ const extractHtmlFromSolverPayload = (payload: unknown): string | undefined => {
 
   if (!payload || typeof payload !== 'object') {
     return undefined;
+  }
+
+  for (const path of SOLVER_KNOWN_PATHS) {
+    const candidate = getValueAtPath(payload, path);
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate;
+    }
   }
 
   const visited = new Set<object>();


### PR DESCRIPTION
## Summary
- inspect common solver JSON payload paths (solution.response, result.html, etc.) before falling back to the raw body
- extend Cloudflare fallback tests to cover nested solver responses

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dd4e8c4b748325bc9675d1f84e851d